### PR TITLE
FIX/src/components/Mint.js: use FileReader API to properly read file to buffer

### DIFF
--- a/src/components/Mint.js
+++ b/src/components/Mint.js
@@ -51,6 +51,16 @@ export default class Mint extends Component {
     })
   }
 
+  fileToArrayBuffer = (file) => {
+    return new Promise((resolve, reject) => {
+      const fileReader = new FileReader()
+      const arrayBuffer = (fileReader.onload = (evt) => {
+        resolve(evt.target.result)
+      })
+      fileReader.readAsArrayBuffer(file)
+    })
+  }
+
   onFileUpload = async (e) => {
     if (this.context.Tezos == null) {
       alert('sync')
@@ -67,15 +77,12 @@ export default class Mint extends Component {
         protocol: 'https',
       })
 
-      console.log(files)
-      console.log(Buffer.from(await files[0].arrayBuffer()))
-
       // 40mb limit
       if (files[0].size < 40000000) {
+        const arrayBuffer = await this.fileToArrayBuffer(files[0])
+        console.log(arrayBuffer)
         const fileCid =
-          'ipfs://' +
-          (await ipfs.files.add(Buffer.from(await files[0].arrayBuffer())))[0]
-            .hash
+          'ipfs://' + (await ipfs.files.add(Buffer.from(arrayBuffer)))[0].hash
         const nftCid = (
           await ipfs.files.add(
             Buffer.from(


### PR DESCRIPTION
I had an error all the time I was trying to mint new objkts today. My browsers console told me that the conversion to buffer seemed to be wrong somehow:

[www.hicetnunc.xyz-1615125672146.log](https://github.com/hicetnunc2000/hicetnunc/files/6097253/www.hicetnunc.xyz-1615125672146.log)

[Added the log output here:]
```
main.0517141f.chunk.js:1 /mint
main.0517141f.chunk.js:1 Object
main.0517141f.chunk.js:1 Object
main.0517141f.chunk.js:1 Object
DevTools failed to parse SourceMap: https://www.hicetnunc.xyz/static/js/main.0517141f.chunk.js.map
DevTools failed to parse SourceMap: https://www.hicetnunc.xyz/static/js/2.8b2155a1.chunk.js.map
DevTools failed to parse SourceMap: https://www.hicetnunc.xyz/static/css/2.87a9c7a2.chunk.css.map
DevTools failed to parse SourceMap: https://www.hicetnunc.xyz/static/css/main.139808ee.chunk.css.map
2.8b2155a1.chunk.js:2 715db042-1b02-4527-0fa3-ea9cd8fbb5db: 0.84130859375ms init done
2.8b2155a1.chunk.js:2 715db042-1b02-4527-0fa3-ea9cd8fbb5db: 11.713134765625ms sending
2.8b2155a1.chunk.js:2 715db042-1b02-4527-0fa3-ea9cd8fbb5db: 13.5771484375ms sent
2.8b2155a1.chunk.js:2 715db042-1b02-4527-0fa3-ea9cd8fbb5db: 1444.9912109375ms response
2.8b2155a1.chunk.js:2 715db042-1b02-4527-0fa3-ea9cd8fbb5db: 1445.228271484375ms
main.0517141f.chunk.js:1 {pathname: "", address: "tz1Z9s59QUmYTs4NKf48uHhcgeY5wimpFWiX", op: undefined, contract: "", setAddress: ƒ, …}
2.8b2155a1.chunk.js:2 Invalid asm.js: Unexpected token
main.0517141f.chunk.js:1 FileList {0: File, length: 1}
main.0517141f.chunk.js:1 Uncaught (in promise) TypeError: n[0].arrayBuffer is not a function
    at main.0517141f.chunk.js:1
    at c (2.8b2155a1.chunk.js:2)
    at Generator._invoke (2.8b2155a1.chunk.js:2)
    at Generator.next (2.8b2155a1.chunk.js:2)
    at n (2.8b2155a1.chunk.js:2)
    at s (2.8b2155a1.chunk.js:2)
    at 2.8b2155a1.chunk.js:2
    at new Promise (<anonymous>)
    at A.<anonymous> (2.8b2155a1.chunk.js:2)
    at A.<anonymous> (main.0517141f.chunk.js:1)
(anonymous) @ main.0517141f.chunk.js:1
c @ 2.8b2155a1.chunk.js:2
(anonymous) @ 2.8b2155a1.chunk.js:2
(anonymous) @ 2.8b2155a1.chunk.js:2
n @ 2.8b2155a1.chunk.js:2
s @ 2.8b2155a1.chunk.js:2
(anonymous) @ 2.8b2155a1.chunk.js:2
(anonymous) @ 2.8b2155a1.chunk.js:2
(anonymous) @ main.0517141f.chunk.js:1
s @ 2.8b2155a1.chunk.js:2
p @ 2.8b2155a1.chunk.js:2
(anonymous) @ 2.8b2155a1.chunk.js:2
y @ 2.8b2155a1.chunk.js:2
at @ 2.8b2155a1.chunk.js:2
it @ 2.8b2155a1.chunk.js:2
st @ 2.8b2155a1.chunk.js:2
pt @ 2.8b2155a1.chunk.js:2
Q @ 2.8b2155a1.chunk.js:2
F @ 2.8b2155a1.chunk.js:2
Zt @ 2.8b2155a1.chunk.js:2
Xt @ 2.8b2155a1.chunk.js:2
t.unstable_runWithPriority @ 2.8b2155a1.chunk.js:2
Gi @ 2.8b2155a1.chunk.js:2
D @ 2.8b2155a1.chunk.js:2
Wt @ 2.8b2155a1.chunk.js:2
```

Did som minor changes using FileReader to fix this. Seemed to work, at least I could mint one new OBJKT from my hicetnunc running on localhost:
https://www.hicetnunc.xyz/objkt/1600