### PR TITLE
replace link by button to maintain scroll position

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,6 +16,11 @@ button {
   border-top: 0;
   border-left: 0;
 }
+
+.nav button:focus {
+  outline: thin dotted;
+}
+
 /* a {
   color : #000
 }

--- a/src/components/AppNavbar.js
+++ b/src/components/AppNavbar.js
@@ -10,9 +10,10 @@ import {
   NavItem,
   NavLink,
 } from 'reactstrap'
-import { HicetnuncContext } from '../context/HicetnuncContext'
 import { Card, Col, Row } from 'reactstrap'
 import { keyframes } from 'styled-components'
+import { HicetnuncContext } from '../context/HicetnuncContext'
+import Button from './Button'
 import '../App.css'
 
 const axios = require('axios')
@@ -82,18 +83,14 @@ export default class AppNavbar extends Component {
       textDecoration: 'none',
     }
 
-    let logo = {
+    let sync = {
       right: '0',
       position: 'absolute',
       top: '0',
       marginTop: '17px',
       marginRight: '70px',
-      color: '#000',
-      '&:hover': {
-        color: '#000',
-      },
-      textDecoration: 'none',
     }
+
     return (
       <div style={{ position: 'fixed', top: 0, width: '100%', zIndex: 100 }}>
         <Row>
@@ -112,9 +109,13 @@ export default class AppNavbar extends Component {
               <a href="/" style={logoLetters}>
                 hic et nunc
               </a>
-              <a href="#" style={logo} onClick={this.context.syncTaquito}>
+              <Button
+                style={sync}
+                onClick={this.context.syncTaquito}
+                label="sync"
+              >
                 sync
-              </a>
+              </Button>
               <div onClick={this.context.toogleNavbar}>
                 <a href="#">
                   <img

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,22 @@
+import React from 'react'
+
+const Button = function (props) {
+  const { onClick, style: additionalStyle, label } = props
+  const style = {
+    color: '#000',
+    textDecoration: 'none',
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    cursor: 'pointer',
+    ...additionalStyle,
+  }
+
+  return (
+    <button style={style} onClick={onClick}>
+      {label}
+    </button>
+  )
+}
+
+export default Button


### PR DESCRIPTION
fix #19

fixed after the warning supplied by eslint: 

> jsx-a11y/anchor-is-valid: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cann... a bu
tton and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md

The added styles are here to cancel default button styles

Did not used reactstrap *<Button/>* element because it embeds a focus pseudo-class and it can't be overriden with styles specified via javascript

All the styles may need a great rework later, this MR is just a quick fix