### PR TITLE
add a space after title, description, tags

### DIFF
--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -194,7 +194,7 @@ export default class ObjktDisplay extends Component {
                           </a>
                         </span>
                       </span>
-          
+
                       {owners
                         ? owners_arr.map((e) => (
                             <div>
@@ -268,16 +268,16 @@ export default class ObjktDisplay extends Component {
                     {info && (
                       <div className={styles.info}>
                         <div>
-                          <strong>title:</strong>
+                          <strong>title: </strong>
                           {objkt.name}
                         </div>
                         <div>
-                          <strong>description:</strong>
+                          <strong>description: </strong>
                           {objkt.token_info.description}
                         </div>
                         {objkt.token_info.tags.length > 0 && (
                           <div>
-                            <strong>tags:</strong>
+                            <strong>tags: </strong>
                             {objkt.token_info.tags.map((tag, index) => {
                               return <div key={`tag${tag}${index}`}>{tag}</div>
                             })}


### PR DESCRIPTION
In the spirit of tiny, easy to accept pull-requests, adding some space between the `:` and the value in the item details pages.
Line 197 was an auto-format by prettier :)