### PR TITLE
delimit tags by comma instead of newline

### DIFF
--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -194,7 +194,7 @@ export default class ObjktDisplay extends Component {
                           </a>
                         </span>
                       </span>
-          
+
                       {owners
                         ? owners_arr.map((e) => (
                             <div>
@@ -279,7 +279,11 @@ export default class ObjktDisplay extends Component {
                           <div>
                             <strong>tags:</strong>
                             {objkt.token_info.tags.map((tag, index) => {
-                              return <div key={`tag${tag}${index}`}>{tag}</div>
+                              return (
+                                <span key={`tag${tag}${index}`}>
+                                  {index !== 0 ? `, ${tag}` : tag}
+                                </span>
+                              )
                             })}
                           </div>
                         )}


### PR DESCRIPTION
I noticed some tags make the page really long and it's easy enough to delimit with a comma