### PR TITLE
Replace sync alert with Taquito syncing function

### DIFF
--- a/src/pages/display.js
+++ b/src/pages/display.js
@@ -30,7 +30,6 @@ export default class Display extends Component {
     console.log(this.context.getAuth())
     await axios
       .post(process.env.REACT_APP_TZ, {
-        // 3.129.20.231
         tz: window.location.pathname.split('/')[2],
       })
       .then(async (res) => {

--- a/src/pages/display.js
+++ b/src/pages/display.js
@@ -30,6 +30,7 @@ export default class Display extends Component {
     console.log(this.context.getAuth())
     await axios
       .post(process.env.REACT_APP_TZ, {
+        // 3.129.20.231
         tz: window.location.pathname.split('/')[2],
       })
       .then(async (res) => {

--- a/src/pages/feed.js
+++ b/src/pages/feed.js
@@ -72,7 +72,7 @@ export default class Feed extends Component {
   collect = (event, index) => {
     console.log(index)
     if (this.context.Tezos == null) {
-      alert('sync')
+      this.context.syncTaquito()
     } else {
       this.context.collect(
         1,


### PR DESCRIPTION
I've replaced the alert that says "sync" and instead it now launches the wallet sync function (this.context.syncTaquito) to save the user from having to click the sync button after the closing the "sync" alert. Here's a video:


https://user-images.githubusercontent.com/14209806/110433936-051d4500-8116-11eb-93a4-ba400d355457.mov

