### PR TITLE
show decimal precision for prices

### DIFF
--- a/src/pages/feed.js
+++ b/src/pages/feed.js
@@ -239,10 +239,10 @@ export default class Feed extends Component {
                                   {this.state.items[index].swaps.length != 0 ? (
                                     <span>
                                       collect for{' '}
-                                      {parseInt(
+                                      {
                                         this.state.items[index].swaps[0]
                                           .xtz_per_objkt / 1000000
-                                      )}{' '}
+                                      }{' '}
                                       tez
                                     </span>
                                   ) : (

--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -135,7 +135,7 @@ export default class ObjktDisplay extends Component {
                         {objkt.swaps.length !== 0 ? (
                           <span>
                             collect for{' '}
-                            {parseInt(objkt.swaps[0].xtz_per_objkt / 1000000)}{' '}
+                            {objkt.swaps[0].xtz_per_objkt / 1000000}{' '}
                             tez
                           </span>
                         ) : (


### PR DESCRIPTION
parseInt is hiding the real price of pieces. Items under 1 show up as 0, etc. This allows the real price to be displayed.

<img width="679" alt="Screen Shot 2021-03-09 at 7 26 31 PM" src="https://user-images.githubusercontent.com/70015/110572076-94722a80-810d-11eb-9bdd-34d921e7c894.png">
