### PR TITLE
use ipfs.io instead of dweb.link so videos render

### DIFF
--- a/src/components/media-types/index.js
+++ b/src/components/media-types/index.js
@@ -25,7 +25,7 @@ export const renderMediaType = (token_info, interactive) => {
     case MIMETYPE.MP4:
     case MIMETYPE.OGG:
     case MIMETYPE.QUICKTIME:
-      url = `https://dweb.link/ipfs/${path}`
+      url = `https://ipfs.io/ipfs/${path}`
       return <VideoComponent src={url} />
     /* 3D */
     case MIMETYPE.GLTF:


### PR DESCRIPTION
I think this was meant to be accepted but got overwritten in some refactoring.

Videos are still broken presently in Safari (e.g. https://www.hicetnunc.xyz/objkt/3007)

<img width="814" alt="Screen Shot 2021-03-11 at 2 35 22 PM" src="https://user-images.githubusercontent.com/70015/110864506-13cf3d80-8277-11eb-845d-0fb3a8bf52e8.png">


Running this branch locally plays the video: http://localhost:3000/objkt/3007