### PR TITLE
Fixed the bug where tags are outside of the view if there are too many

### DIFF
--- a/src/pages/objkt-display/index.module.scss
+++ b/src/pages/objkt-display/index.module.scss
@@ -16,6 +16,7 @@
 
 .tags {
   display: flex;
+	flex-wrap: wrap;
   align-items: center;
 
   .tag {

--- a/src/pages/objkt-display/index.module.scss
+++ b/src/pages/objkt-display/index.module.scss
@@ -16,8 +16,8 @@
 
 .tags {
   display: flex;
-	flex-wrap: wrap;
   align-items: center;
+  flex-wrap: wrap;
 
   .tag {
     display: inline-flex;


### PR DESCRIPTION
Adding flex-wrap; wrap makes sure the outer container wraps and tags go to a new line if required.