### PR TITLE
Added spacing to grid rows so items have vertical spacing too

### DIFF
--- a/src/pages/display/index.module.scss
+++ b/src/pages/display/index.module.scss
@@ -31,6 +31,7 @@
   margin-top: 100px;
   display: grid;
   grid-column-gap: 10px;
+	grid-row-gap: 10px;
   grid-template-columns: repeat(1, minmax(0, 1fr));
 
   @include respond-to('tablet') {


### PR DESCRIPTION
Currently there's no vertical spacing in the display grid so items touch each other. This adds the same spacings thats used horizontally to the rows so it looks better. 