### PR TITLE
show sold out! message - and editions when no swaps are present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ yarn-error.log*
 
 TODO.md
 
+.DS_Store
+
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml

--- a/src/components/item-info/index.js
+++ b/src/components/item-info/index.js
@@ -9,15 +9,21 @@ export const ItemInfo = ({
   token_id,
   token_info,
   swaps,
+  transfered,
   total_amount,
   isDetailView,
 }) => {
   const context = useContext(HicetnuncContext)
 
   const notForSale = swaps.length === 0
+  const soldOut = notForSale && transfered > 0
   const price = swaps.length > 0 && Number(swaps[0].xtz_per_objkt) / 1000000
-  const edition = swaps.length && `${swaps[0].objkt_amount}/${total_amount}`
-  const message = notForSale ? 'not for sale' : `collect for ${price} tez`
+  const edition = notForSale
+    ? total_amount
+    : swaps.length && `${swaps[0].objkt_amount}/${total_amount}`
+
+  const soldOutMessage = soldOut ? 'sold out!' : 'not for sale'
+  const message = notForSale ? soldOutMessage : `collect for ${price} tez`
 
   const handleCollect = () => {
     if (context.Tezos == null) {
@@ -37,7 +43,7 @@ export const ItemInfo = ({
               <Primary>{walletPreview(token_info.creators[0])}</Primary>
             </Button>
           </div>
-          {!notForSale && <p>Edition: {edition}</p>}
+          <p>Edition: {edition}</p>
         </div>
       </div>
 


### PR DESCRIPTION
This one was annoying me - I think it's important to show when OBJKTS are sold out vs not for sale.

Also the editions should be present in this case.

I've left the editions enabled for when it's "not for sale" as that was cleaner and I couldn't think of any reason why they shouldn't show there as well?