### PR TITLE
Update index.js for /about

### DIFF
--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -62,7 +62,7 @@ export class About extends Component {
               &nbsp;
               <Button href="mailto:hicetnunc2000@protonmail.com">
                 <Primary>
-                  <strong>email</strong>
+                  <strong>email</strong>&nbsp;
                 </Primary>
               </Button>
               <p>or on</p>&nbsp;


### PR DESCRIPTION
Added a nbsp after the "email" button, as the current website reads "...get in touch by **email**or on **discord**" (note the lack of space between "email" and "or")