### PR TITLE
Feature/footer refactor

### DIFF
--- a/src/components/footer/index.module.scss
+++ b/src/components/footer/index.module.scss
@@ -1,9 +1,7 @@
 @import '../../styles/variables.scss';
 
 .container {
-  position: fixed;
-  left: 0;
-  bottom: 0;
+  position: relative;
   padding: 2px 0;
   width: 100%;
   text-align: center;
@@ -13,10 +11,4 @@
   transition: background-color #{$theme-duration} ease-out,
     color #{$theme-duration} ease-out;
   z-index: 2000;
-
-  // & > * {
-  //   :last-child {
-  //     font-size: 50%;
-  //   }
-  // }
 }

--- a/src/pages/feed/index.js
+++ b/src/pages/feed/index.js
@@ -100,23 +100,25 @@ export const Feed = () => {
             <Loading />
           </Padding>
         </Container>
-      ) : hasMore ? (
+      ) : (
         <Container>
           <Padding>
-            <Button onClick={loadMore}>
-              <Primary>
-                <strong>Load More</strong>
-              </Primary>
-            </Button>
+            {hasMore ? (
+              <Button onClick={loadMore}>
+                <Primary>
+                  <strong>Load More</strong>
+                </Primary>
+              </Button>
+            ) : (
+              <p>
+                mint mint mint{' '}
+                <span role="img" aria-labelledby={'Sparkles emoji'}>
+                  ✨
+                </span>
+              </p>
+            )}
           </Padding>
         </Container>
-      ) : (
-        <p>
-          mint mint mint{' '}
-          <span role="img" aria-labelledby={'Sparkles emoji'}>
-            ✨
-          </span>
-        </p>
       )}
     </Page>
   )

--- a/src/pages/feed/index.js
+++ b/src/pages/feed/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react'
-import InfiniteScroll from 'react-infinite-scroll-component'
 import { GetFeed, GethDAOFeed } from '../../data/api'
 import { Page, Container, Padding } from '../../components/layout'
 import { FeedItem } from '../../components/feed-item'
@@ -9,20 +8,18 @@ import { Button, Primary } from '../../components/button'
 import styles from './index.module.scss'
 
 export const Feed = () => {
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [feedType, setFeedType] = useState(1)
   const [items, setItems] = useState([])
   const [count, setCount] = useState(0)
   const [hasMore, setHasMore] = useState(true)
-  console.log('feed av')
 
   const loadMore = () => {
     setCount(count + 1)
   }
 
   useEffect(() => {
-    console.log('use effect')
-
     if (error) {
       console.log('returning on error')
       return
@@ -31,11 +28,14 @@ export const Feed = () => {
     if (feedType === 0) {
       console.log('hDAO feed')
 
+      setLoading(true)
       // api
       GethDAOFeed({ counter: count })
         .then((result) => {
           const next = items.concat(result)
           setItems(next)
+
+          setLoading(false)
 
           if (result.length < 10) {
             setHasMore(false)
@@ -43,24 +43,27 @@ export const Feed = () => {
         })
         .catch((e) => {
           setError(true)
+          setLoading(false)
         })
     } else {
       console.log('latest feed')
 
+      setLoading(true)
       // api
       GetFeed({ counter: count })
         .then(({ filtered, original }) => {
           // filtered isn't guaranteed to always be 10. if we're filtering they might be less.
           const next = items.concat(filtered)
           setItems(next)
-          console.log(filtered)
-          // if original returns less than 10, then there's no more data coming from API
+          setLoading(false)
+          // if original returns less than 30, then there's no more data coming from API
           if (original.length < 30) {
             setHasMore(false)
           }
         })
         .catch((e) => {
           setError(true)
+          setLoading(false)
         })
     }
   }, [count, feedType])
@@ -87,36 +90,27 @@ export const Feed = () => {
         </div>
       )}
 
-      <InfiniteScroll
-        dataLength={items.length}
-        next={loadMore}
-        hasMore={hasMore}
-        loader={
-          <Container>
-            <Padding>
-              <div className={styles.container}>
-                <Loading />
-              </div>
-            </Padding>
-          </Container>
-        }
-        endMessage={
-          <Container>
-            <Padding>
-              <p>
-                mint mint mint{' '}
-                <span role="img" aria-labelledby={'Sparkles emoji'}>
-                  ✨
-                </span>
-              </p>
-            </Padding>
-          </Container>
-        }
-      >
-        {items.map((item, index) => (
-          <FeedItem key={`${item.token_id}-${index}`} {...item} />
-        ))}
-      </InfiniteScroll>
+      {items.map((item, index) => (
+        <FeedItem key={`${item.token_id}-${index}`} {...item} />
+      ))}
+
+      {loading ? (
+        <Container>
+          <Padding>
+            <Loading />
+          </Padding>
+        </Container>
+      ) : (
+        <Container>
+          <Padding>
+            <Button onClick={loadMore}>
+              <Primary>
+                <strong>Load More</strong>
+              </Primary>
+            </Button>
+          </Padding>
+        </Container>
+      )}
     </Page>
   )
 }

--- a/src/pages/feed/index.js
+++ b/src/pages/feed/index.js
@@ -100,18 +100,23 @@ export const Feed = () => {
             <Loading />
           </Padding>
         </Container>
+      ) : hasMore ? (
+        <Container>
+          <Padding>
+            <Button onClick={loadMore}>
+              <Primary>
+                <strong>Load More</strong>
+              </Primary>
+            </Button>
+          </Padding>
+        </Container>
       ) : (
-        hasMore && (
-          <Container>
-            <Padding>
-              <Button onClick={loadMore}>
-                <Primary>
-                  <strong>Load More</strong>
-                </Primary>
-              </Button>
-            </Padding>
-          </Container>
-        )
+        <p>
+          mint mint mint{' '}
+          <span role="img" aria-labelledby={'Sparkles emoji'}>
+            ✨
+          </span>
+        </p>
       )}
     </Page>
   )

--- a/src/pages/feed/index.js
+++ b/src/pages/feed/index.js
@@ -101,15 +101,17 @@ export const Feed = () => {
           </Padding>
         </Container>
       ) : (
-        <Container>
-          <Padding>
-            <Button onClick={loadMore}>
-              <Primary>
-                <strong>Load More</strong>
-              </Primary>
-            </Button>
-          </Padding>
-        </Container>
+        hasMore && (
+          <Container>
+            <Padding>
+              <Button onClick={loadMore}>
+                <Primary>
+                  <strong>Load More</strong>
+                </Primary>
+              </Button>
+            </Padding>
+          </Container>
+        )
       )}
     </Page>
   )


### PR DESCRIPTION
As suggested on Discord here's what I think we should do:

* The feed should **NOT** automatically load new items as the user scroll to the end of the page. Instead it should load on demand as the user presses a "Load More" button.

**Why?**
By implementing this change, we're able to move the footer to the end of the page. Which will be a huge improvement on mobile where the footer occupies quite a bit of available area.

On mobile the theme button overrides the text in the footer, and the only solution for that would be increase the size of the footer by introducing a row for buttons and a row for text which will further reduce the amount of available space for mobile.

Furthermore there's a feature request to add multi language [#173](https://github.com/hicetnunc2000/hicetnunc/issues/173) and that's another button that needs to go on the footer and therefore further accelerate the need to properly style the footer and potencially increase its height.

This proposal makes for a elegant solution plus removes a dependency on [react-infinite-scroll-component](https://www.npmjs.com/package/react-infinite-scroll-component)

One this PR gets merged, I can work on the ability to virtualise the rendered nft's. What do I mean by that? If the user loads 30, 60, 90, 120 etc they are rendering all those elements on the page. virtualisation will enable to only render the necessary cells to fill up the screen height, and then we're simply swapping the content of those html nodes.

But that's an improvement to this first version.