### PR TITLE
Fixes for Vector/HTML iframe query param names and templates

### DIFF
--- a/src/components/media-types/html/index.js
+++ b/src/components/media-types/html/index.js
@@ -11,11 +11,11 @@ export const HTMLComponent = ({ src, interactive, preview, token_info }) => {
     [styles.interactive]: interactive,
   })
 
-  let _author_ = false
+  let _creator_ = false
   let _viewer_ = false
 
   if (token_info && token_info.creators[0]) {
-    _author_ = token_info.creators[0]
+    _creator_ = token_info.creators[0]
   }
 
   if (context.address !== '') {
@@ -26,7 +26,7 @@ export const HTMLComponent = ({ src, interactive, preview, token_info }) => {
   if (preview) {
     safeSrc = injectCSPMetaTagIntoDataURI(src)
   } else {
-    safeSrc = `${src}?author=${_author_}&viewer=${_viewer_}`
+    safeSrc = `${src}?creator=${_creator_}&viewer=${_viewer_}`
   }
 
   return (

--- a/src/components/media-types/vector/index.js
+++ b/src/components/media-types/vector/index.js
@@ -10,11 +10,11 @@ export const VectorComponent = ({ src, interactive, preview, token_info }) => {
     [styles.interactive]: interactive,
   })
 
-  let _author_ = false
+  let _creator_ = false
   let _viewer_ = false
 
   if (token_info && token_info.creators[0]) {
-    _author_ = token_info.creators[0]
+    _creator_ = token_info.creators[0]
   }
 
   if (context.address !== '') {
@@ -25,7 +25,7 @@ export const VectorComponent = ({ src, interactive, preview, token_info }) => {
   if (preview) {
     iframeSrc = src
   } else {
-    iframeSrc = `${src}?author=${_author_}&viewer=${_viewer_}`
+    iframeSrc = `${src}?creator=${_creator_}&viewer=${_viewer_}`
   }
 
   return (

--- a/templates/generative.html
+++ b/templates/generative.html
@@ -6,10 +6,6 @@
     <style>
       html,
       body {
-        background-color: #efefef;
-        font-family: sans-serif;
-        font-size: 1rem;
-        font-weight: bold;
         margin: 0;
         padding: 0;
         pointer-events: none;
@@ -18,25 +14,11 @@
         -ms-user-select: none;
         user-select: none;
       }
-
-      .wrapper {
-        position: fixed;
-        width: 100vw;
-        height: 100vh;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .wrapper > div {
-        width: 100%;
-        height: 50%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-      }
     </style>
   </head>
   <body>
+    <!-- NOTE: All external resources will be blocked! -->
+
     <script type="text/javascript">
       const c = new URLSearchParams(location.search).get('creator')
       const v = new URLSearchParams(location.search).get('viewer')


### PR DESCRIPTION
A couple of small fixes:
- The Vector/HTML iframes were adding the query param `author`, while the templates were referencing `creator`. I changed it so they both use `creator` since this is the term used in the metadata.
- Simplified the HTML template and added a comment so users are aware that external sources will be blocked (i.e. trying to load three.js or p5.js cdn)