### PR TITLE
use lowest price for current swap and price display

### DIFF
--- a/src/components/item-info/index.js
+++ b/src/components/item-info/index.js
@@ -4,7 +4,7 @@ import { Button, Primary, Purchase } from '../button'
 import { HicetnuncContext } from '../../context/HicetnuncContext'
 import { walletPreview } from '../../utils/string'
 import styles from './index.module.scss'
-// import { lowestPrice } from '../../utils/lowestPrice'
+import { lowestPrice } from '../../utils/lowestPrice'
 // import { getTotalSales } from '../../utils/sanitise'
 
 const _ = require('lodash')
@@ -32,18 +32,19 @@ export const ItemInfo = ({
   // var kt = _.values(_.omitBy(owners, (value, key) => !key.startsWith('KT')))[0]
   //owners = _.values(_.omitBy(owners, (value, key) => !key.startsWith(token_info.creators[0])))
 
+  const swap = lowestPrice(swaps);
   const soldOutMessage = 'not for sale'
   //const notForSale = available > 0 || isNaN(editions)
   const message =
     available > 0
-      ? 'collect for ' + Number(swaps[0].xtz_per_objkt) / 1000000 + ' tez'
+      ? 'collect for ' + Number(swap.xtz_per_objkt) / 1000000 + ' tez'
       : 'not for sale'
 
   const handleCollect = () => {
     if (Tezos == null) {
       syncTaquito()
     } else {
-      collect(1, swaps[0].swap_id, swaps[0].xtz_per_objkt * 1)
+      collect(1, swap.swap_id, swaps.xtz_per_objkt * 1)
     }
   }
 

--- a/src/pages/objkt-display/tabs/cancel.js
+++ b/src/pages/objkt-display/tabs/cancel.js
@@ -5,13 +5,13 @@ import { Container, Padding } from '../../../components/layout'
 import { Button, Curate } from '../../../components/button'
 import { Loading } from '../../../components/loading'
 import { PATH } from '../../../constants'
-// import { lowestPrice } from '../../../utils/lowestPrice'
+import { lowestPrice } from '../../../utils/lowestPrice'
 
 // README: Commented a couple of code out to avoid warning. Not sure what crzypathwork was trying to do
 // can we refactor/clean it?
 export const Cancel = ({ swaps, address }) => {
   const { cancel } = useContext(HicetnuncContext)
-  // const { swap_id } = lowestPrice(swaps)
+  const { swap_id } = lowestPrice(swaps)
   const [message, setMessage] = useState()
   const [progress, setProgress] = useState()
   const history = useHistory()
@@ -22,7 +22,7 @@ export const Cancel = ({ swaps, address }) => {
       setProgress(true)
       // console.log(swaps)
       setMessage('cancelling swap')
-      cancel(swaps[0].swap_id)
+      cancel(swap_id)
         .then((e) => {
           // when taquito returns a success/fail message
           setProgress(false)


### PR DESCRIPTION
not sure why this was commented out. Opening back using the lowest price for the current swap. The current site behavior is to just grab the first swap in the array, which isn't always the oldest swap posted.