### PR TITLE
Fixed bug with old IPFS response format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1912,6 +1912,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -5564,6 +5565,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -7702,7 +7704,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -9588,6 +9591,7 @@
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.0.2.tgz",
       "integrity": "sha512-zA/WTEyrJkymmP78/vXf2wCXxofe93CmvaNVG4cA53HNMISW1vbt9lZ9OBiE7KyJR1CWc8agokjr8jmer8JNgQ==",
       "dependencies": {
+        "@emotion/is-prop-valid": "^0.8.2",
         "framesync": "5.2.3",
         "hey-listen": "^1.0.8",
         "popmotion": "9.3.4",
@@ -12457,6 +12461,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -13960,6 +13965,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -18327,6 +18333,7 @@
         "eslint-webpack-plugin": "^2.5.2",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
+        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -22422,8 +22429,10 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -22513,6 +22522,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -22737,6 +22747,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
       "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+      "dependencies": {
+        "@zxing/text-encoding": "0.9.0"
+      },
       "optionalDependencies": {
         "@zxing/text-encoding": "0.9.0"
       }
@@ -22964,6 +22977,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -23458,6 +23472,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -23965,6 +23982,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/src/data/ipfs.js
+++ b/src/data/ipfs.js
@@ -12,12 +12,11 @@ export const prepareFile = async ({
   mimeType,
 }) => {
   const ipfs = createClient('https://ipfs.infura.io:5001')
-  const hash = await ipfs.add(buffer)
-  const cid = `ipfs://${hash[0].hash}`
+  const info = await ipfs.add(buffer)
+  const hash = info.path
+  const cid = `ipfs://${hash}`
 
-  console.log(hash, cid)
-
-  const result = await uploadMetadataFile({
+  return await uploadMetadataFile({
     name,
     description,
     tags,
@@ -25,7 +24,6 @@ export const prepareFile = async ({
     address,
     mimeType
   })
-  return result
 }
 
 export const prepareDirectory = async ({
@@ -37,12 +35,9 @@ export const prepareDirectory = async ({
 }) => {
   // upload files
   const hash = await uploadFilesToDirectory(files)
-
   const cid = `ipfs://${hash}`
 
-  console.log(hash, cid)
-
-  const result = await uploadMetadataFile({
+  return await uploadMetadataFile({
     name,
     description,
     tags,
@@ -50,7 +45,6 @@ export const prepareDirectory = async ({
     address,
     mimeType: 'application/x-directory'
   })
-  return result
 }
 
 function not_directory(file) {
@@ -59,18 +53,15 @@ function not_directory(file) {
 
 async function uploadFilesToDirectory (files) {
   files = files.filter(not_directory)
-  console.log('Upload files to IPFS')
-  console.log(files)
 
   const form = new FormData()
 
   files.forEach(file => {
     form.append('file', file.blob, encodeURIComponent(file.path))
   })
-  console.log(form)
   const endpoint = 'https://ipfs.infura.io:5001/api/v0/add?pin=true&recursive=true&wrap-with-directory=true'
   const res = await axios.post(endpoint, form, {
-    headers: { "Content-Type": "multipart/form-data" }
+    headers: { 'Content-Type': 'multipart/form-data' }
   })
 
   const data = readJsonLines(res.data)
@@ -81,9 +72,7 @@ async function uploadFilesToDirectory (files) {
 async function uploadMetadataFile({name, description, tags, cid, address, mimeType}) {
   const ipfs = createClient('https://ipfs.infura.io:5001')
 
-  console.log('create metadata file!')
-
-  const result = await ipfs.add(
+  return await ipfs.add(
     Buffer.from(
       JSON.stringify({
         name,
@@ -100,8 +89,4 @@ async function uploadMetadataFile({name, description, tags, cid, address, mimeTy
       })
     )
   )
-
-  console.log(result)
-
-  return result
 }

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -87,7 +87,9 @@ export const Mint = () => {
       })
     }
 
-    mint(getAuth(), amount, nftCid[0].hash, 10)
+    console.log('nftCid:', nftCid)
+
+    mint(getAuth(), amount, nftCid.path, 10)
       .then((e) => {
         console.log('mint confirm', e)
         setMessage('Minted successfully')


### PR DESCRIPTION
After switching to new IPFS library, the mint() function was getting an invalid input for the hash. Fixed now.