### PR TITLE
Added cover image in metadata for HTML/ZIP media type

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -116,3 +116,18 @@ export function injectCSPMetaTagIntoHTML(html) {
   // doc -> HTML
   return doc.documentElement.innerHTML
 }
+
+export function getCoverImagePathFromBuffer(buffer) {
+  // buffer -> html
+  const html = new TextDecoder().decode(buffer)
+
+  // html -> doc
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+
+  const meta = doc.querySelector('meta[property="cover-image"]')
+
+  if (!meta) return null
+
+  return meta.getAttribute('content')
+}

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -130,7 +130,7 @@ export function getCoverImagePathFromBuffer(buffer) {
   const parser = new DOMParser()
   const doc = parser.parseFromString(html, 'text/html')
 
-  const meta = doc.querySelector('meta[property="cover-image"]')
+  const meta = doc.querySelector('meta[property="og:image"]')
 
   if (!meta) return null
 


### PR DESCRIPTION
Users will now be able to specify a cover image from their `index.html` page via a meta tag, with  `property` set to `og:image` and `content` set to a relative path to an image in the directory. Ex:

```html
<meta property="og:image" content="path/to/cover.png" />
```

The cover image's IPFS address will be added to the NFT metadata in the field `displayUri`.

@andrevenancio, you can use this value to display the cover image in the feed!
