### PR TITLE
Load languages locally so we can test translations

### DIFF
--- a/public/languages
+++ b/public/languages
@@ -1,0 +1,1 @@
+../languages

--- a/src/App.js
+++ b/src/App.js
@@ -22,8 +22,11 @@ const App = () => {
   //
   useEffect(() => {
     const language = getItem('language') || setItem('language', 'en')
+    const langRoot = process.env.NODE_ENV === 'development' ?
+      '/languages' :
+      'https://raw.githubusercontent.com/hicetnunc2000/hicetnunc/main/languages'
     fetch(
-      `https://raw.githubusercontent.com/hicetnunc2000/hicetnunc/main/languages/${language}.json`
+      `${langRoot}/${language}.json`
     )
       .then((e) => e.json())
       .then((data) => {


### PR DESCRIPTION
Just started to work on translations and noticed that languages are loaded from github. This PR moves the `languages` folder to `public`, makes a symbolic link `public/languages` (back to) -> `languages` and makes the `App` load language from the `public` folder instead of loading them from github.