### PR TITLE
quick fix for Webkit/Safari CSP issues with HTML type

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -133,10 +133,12 @@ export function injectCSPMetaTagIntoHTML(html) {
       'self';
     script-src
       'self'
-      'unsafe-inline';
+      'unsafe-inline'
+      https://cloudflare-ipfs.com/;
     style-src
       'self'
-      'unsafe-inline';
+      'unsafe-inline'
+      https://cloudflare-ipfs.com/;
     img-src
       'self'
       data:


### PR DESCRIPTION
Adding cdn as valid sources in CSP. Should fix issues with Webkit-based browsers like Safari.

(Note: This is separate from the CORS issues with Cloudflare)