### PR TITLE
Autoplay Checks for Visibility Before Running Videos

### DIFF
--- a/src/components/media-types/index.js
+++ b/src/components/media-types/index.js
@@ -72,7 +72,7 @@ export const renderMediaType = ({
     case MIMETYPE.QUICKTIME:
     case MIMETYPE.WEBM:
       url = preview ? uri : `${IPFS}${path}`
-      return <VideoComponent src={url} interactive={interactive} />
+      return <VideoComponent src={url} interactive={interactive} {...metadata} />
     /* 3D */
     case MIMETYPE.GLB:
     case MIMETYPE.GLTF:

--- a/src/components/media-types/video/index.js
+++ b/src/components/media-types/video/index.js
@@ -1,10 +1,31 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import styles from './index.module.scss'
 
-export const VideoComponent = ({ src }) => {
+export const VideoComponent = (props) => {
+
+  const domElement = useRef();
+
+  useEffect(() => {
+
+    var rect = domElement.current.getBoundingClientRect();
+    var isVisibleH = rect.left < window.innerWidth && rect.right > 0;
+    var isVisibleV = rect.top < window.innerHeight && rect.bottom > 0;
+
+    if (isVisibleH && isVisibleV) {
+      if (domElement.current.paused) {
+        domElement.current.play();
+      }
+    } else {
+      if (!domElement.current.paused) {
+        domElement.current.pause();
+      }
+    }
+
+  }, [props.scroll]);
+
   return (
     <div className={styles.container}>
-      <video className={styles.video} autoPlay muted loop controls src={src} />
+      <video ref={domElement} className={styles.video} preload="true" muted controls loop src={props.src} />
     </div>
   )
 }

--- a/src/pages/feed/index.js
+++ b/src/pages/feed/index.js
@@ -14,6 +14,7 @@ const customFloor = function (value, roundTo) {
 const ONE_MINUTE_MILLIS = 60 * 1000
 
 export const Feed = () => {
+  const [scrollPosition, setScrollPosition] = useState({ x: 0, y: 0 });
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [feedType, setFeedType] = useState(1)
@@ -25,6 +26,25 @@ export const Feed = () => {
   const loadMore = () => {
     setCount(count + 1)
   }
+
+  useEffect(() => {
+
+    window.addEventListener('scroll', onScroll, false);
+
+    return unmount;
+
+    function unmount() {
+      window.removeEventListener('scroll', onScroll, false);
+    }
+
+    function onScroll() {
+      setScrollPosition({
+        x: document.body.scrollLeft,
+        y: document.body.scrollTop
+      });
+    }
+
+  });
 
   useEffect(() => {
     if (error) {
@@ -98,7 +118,7 @@ export const Feed = () => {
       )}
 
       {items.map((item, index) => (
-        <FeedItem key={`${item.token_id}-${index}`} {...item} />
+        <FeedItem key={`${item.token_id}-${index}`} scroll={scrollPosition} {...item} />
       ))}
 
       {loading ? (


### PR DESCRIPTION
👋 

I noticed while browsing the feed and the artist page that there can be performance congestion when there are a lot of videos on one page all autoplaying. I'm submitting a PR that only "autoplays" the video once it's visible on the screen. I know that the contributing guides say not to drill props, but I couldn't think of a more efficient way to dispatch a scroll event to every `VideoComponent`.

More information on dangers of `autoplay` from the Mux team [here](https://mux.com/blog/video-autoplay-considered-harmful/).

Awesome work and community!