### PR TITLE
GLBComponent: Enable AR

### DIFF
--- a/src/components/media-types/glb/index.js
+++ b/src/components/media-types/glb/index.js
@@ -10,6 +10,7 @@ export const GLBComponent = ({ src, interactive }) => {
   const props = {
     className: styles.glb,
     src,
+    'ar': true,
     'autoplay': true,
     'auto-rotate': true,
     'data-js-focus-visible': true,


### PR DESCRIPTION
With this change all the glb files in the site will able to be seen in ar mode (android only for now).

Before merging it, we need to think how to solve the overlapping icons:

![image](https://user-images.githubusercontent.com/97088/113408880-1588ae80-93a8-11eb-9374-2793ca36f52f.png)
