### PR TITLE
Request more detail in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,3 +36,4 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+Please include the wallet address (tz...) and/or the OBJKT number.


### PR DESCRIPTION
This updates the template to request that users include an objkt and/or wallet id in bug tickets to more easily track down issues (especially in upstream APIs)

(Supercedes #380)
