### PR TITLE
Make <INPUT>s clearer

### DIFF
--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -3,25 +3,31 @@ import styles from './index.module.scss'
 
 export const Input = ({
   type = 'text',
-  placeholder = 'placeholder',
+  placeholder = '',
   name = 'input-name-not-set',
   min,
   max,
   maxlength = 500,
   onChange = () => null,
   disabled,
+  label,
+  helpText
 }) => {
   return (
-    <input
-      type={type}
-      placeholder={placeholder}
-      name={name}
-      min={min}
-      max={max}
-      maxLength={maxlength}
-      onChange={onChange}
-      className={styles.container}
-      disabled={disabled}
-    ></input>
+    <div className={styles.container}>
+      <label>{label}
+        <input
+          type={type}
+          placeholder={placeholder}
+          name={name}
+          min={min}
+          max={max}
+          maxLength={maxlength}
+          onChange={onChange}
+          disabled={disabled}
+        ></input>
+        <div className={styles.helpText}>{helpText}</div>
+      </label>
+    </div>
   )
 }

--- a/src/components/input/index.module.scss
+++ b/src/components/input/index.module.scss
@@ -1,15 +1,26 @@
 @import '../../styles/variables.scss';
 
 .container {
-  width: 100%;
-  padding: 6px 0;
-  margin-bottom: 10px;
-  border: none;
-  background-color: transparent;
-  color: var(--text-color);
-  transition: color #{$theme-duration} ease-out;
-
-  &:focus {
-    outline: none;
+  label {
+  }
+  input {
+    width: 100%;
+    padding: 6px 0;
+    margin-bottom: 10px;
+    border: none;
+    background-color: transparent;
+    color: var(--text-color);
+    transition: color #{$theme-duration} ease-out;
+    border: 1px dotted var(--border-color);
+  
+    &:focus {
+      outline: none;
+    }
+  }
+  .helpText {
+    display: block;
+    font-size: 80%;
+    margin-bottom: 15px;
+    margin-top: -10px;
   }
 }

--- a/src/components/upload/index.module.scss
+++ b/src/components/upload/index.module.scss
@@ -8,6 +8,7 @@
     padding: 6px;
     border-style: dashed;
     text-align: center;
+    cursor: pointer;
 
     input {
       display: none;

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -119,34 +119,37 @@ export const Mint = () => {
               <Input
                 type="text"
                 onChange={(e) => setTitle(e.target.value)}
-                placeholder="title"
+                label="TITLE"
               />
 
               <Input
                 type="text"
                 onChange={(e) => setDescription(e.target.value)}
-                placeholder="description"
+                label="DESCRIPTION"
               />
 
               <Input
                 type="text"
                 onChange={(e) => setTags(e.target.value)}
-                placeholder="tags (comma separated. example: illustration, digital, crypto)"
+                label="TAGS"
+                helpText="tags (comma separated. example: illustration, digital, crypto)"
               />
 
               <Input
                 type="number"
                 min={1}
                 onChange={(e) => setAmount(e.target.value)}
-                placeholder="amount"
+                label="QUANTITY"
+                helpText="number of OBJKTs to mint"
               />
 
               <Input
-                type="royalties"
+                type="number"
                 min={0}
                 max={25}
                 onChange={(e) => setRoyalties(e.target.value)}
-                placeholder="your royalties after each sale (between 0-25%)"
+                label="ROYALTY"
+                helpText="your royalties after each sale (between 0-25%)"
               />
             </Padding>
           </Container>

--- a/src/pages/objkt-display/tabs/swap.js
+++ b/src/pages/objkt-display/tabs/swap.js
@@ -47,7 +47,8 @@ export const Swap = ({ total_amount, owners, token_info, address }) => {
         <Padding>
           <Input
             type="number"
-            placeholder="OBJKT amount"
+            label="QUANTITY"
+            helpText="number of OBJKTs"
             min={1}
             defaultValue={amount}
             max={total_amount - sales}
@@ -56,7 +57,8 @@ export const Swap = ({ total_amount, owners, token_info, address }) => {
           />
           <Input
             type="number"
-            placeholder="price per OBJKT (in tez)"
+            label="PRICE"
+            helpText="price per OBJKT (in tez)"
             min={0}
             max={10000}
             onChange={(e) => setPrice(e.target.value)}


### PR DESCRIPTION
feat: changed "AMOUNT" to "QUANTITY" for inputs as this makes more sense in English
feat: added a border around inputs to make them clearer, especially when using labels instead of placeholders
feat: changed <Inputs> to use labels as it is bad practice to only have placeholders and can be confusing and lead to mistakes

It was too easy to make mistakes when minting or swapping. Part of this problem is the fact that only "placeholders" are used in the inputs. I realise this was partly to keep the interface as minimal as possible but made the process of minting / swapping confusing.

I also changed the label "AMOUNT" to "QUANTITY" as this makes it clearer it is referring to the number of OBJKTs. AMOUNT, especially when there is a lack of titles / help text can be confused more easily with price I think. I could be totally wrong with this though.