### PR TITLE
Removed cover image check in meta tag for HTML OBJKTs

### DIFF
--- a/src/components/media-types/html/index.js
+++ b/src/components/media-types/html/index.js
@@ -2,7 +2,11 @@ import React, { useContext, useState, useRef, useEffect } from 'react'
 import classnames from 'classnames'
 import { HicetnuncContext } from '../../../context/HicetnuncContext'
 import { Button } from '../../button'
-import { dataRUIToBuffer, prepareFilesFromZIP, validateFiles } from '../../../utils/html'
+import {
+  dataRUIToBuffer,
+  prepareFilesFromZIP,
+  validateFiles,
+} from '../../../utils/html'
 import { VisuallyHidden } from '../../visually-hidden'
 import styles from './index.module.scss'
 
@@ -106,9 +110,7 @@ export const HTMLComponent = ({
       )
     } else if (validHTML === false) {
       return (
-        <div className={styles.error}>
-          Preview Error: {validationError}
-        </div>
+        <div className={styles.error}>Preview Error: {validationError}</div>
       )
     }
   }

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -251,30 +251,6 @@ export async function validateFiles(files) {
     }
   }
 
-  // check for cover image
-  // TODO: remove this once we switch to cover imgae upload
-  let coverImagePath = getCoverImagePathFromDoc(doc)
-  if (!coverImagePath) {
-    return {
-      valid: false,
-      error:
-        'Missing cover image <meta> tag in index.html. Please refer to the Interactive OBJKTs Guide.',
-    }
-  }
-
-  // check for cover image itself
-  // TODO: remove this once we switch to cover imgae upload
-  if (coverImagePath.indexOf('./') === 0) {
-    coverImagePath = coverImagePath.replace('./', '')
-  }
-
-  if (!files[coverImagePath]) {
-    return {
-      valid: false,
-      error: `Missing cover image ${coverImagePath}. Please refer to the Interactive OBJKTs Guide.`,
-    }
-  }
-
   return {
     valid: true,
   }


### PR DESCRIPTION
The check is no longer necessary as the cover image will be uploaded separately on the mint page.