### PR TITLE
Fix for upload field not allowing .glb file type

### DIFF
--- a/src/components/upload/index.js
+++ b/src/components/upload/index.js
@@ -30,18 +30,20 @@ export const Upload = ({
     reader.readAsDataURL(file)
   }
 
-  const accept = allowedTypes.join(',')
+  const props = {
+    type: 'file',
+    name: 'file',
+  }
+
+  if (allowedTypes) {
+    props['accept'] = allowedTypes.join(',')
+  }
 
   return (
     <div className={styles.container}>
       <label>
         {title}
-        <input
-          type="file"
-          name="file"
-          accept={accept}
-          onChange={onFileChange}
-        />
+        <input {...props} onChange={onFileChange} />
       </label>
       <div className={styles.allowed}>
         {language.mint.supports}:&nbsp;{allowedTypesLabel}

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -249,7 +249,6 @@ export const Mint = () => {
             <Padding>
               <Upload
                 label="Upload OBJKT"
-                allowedTypes={ALLOWED_MIMETYPES}
                 allowedTypesLabel={ALLOWED_FILETYPES_LABEL}
                 onChange={handleFileUpload}
               />


### PR DESCRIPTION
Certain file types like `.glb` are showing up grayed out when trying to upload on mint page. It seems browsers are not recognizing that mime type.

Simply removing the `accept` attribute from the upload field for now.