### PR TITLE
Added blob to script-src in CSP

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -138,7 +138,8 @@ export function injectCSPMetaTagIntoHTML(html) {
     script-src
       'self'
       'unsafe-inline'
-      'unsafe-eval';
+      'unsafe-eval'
+      blob:;
     style-src
       'self'
       'unsafe-inline';


### PR DESCRIPTION
Some often-used packages/libraries use blobs as script sources. 

For example, the p5.sound library: https://github.com/hicetnunc2000/hicetnunc/issues/469

This simply enables `blob` in 'script-src` of CSP.