### PR TITLE
HTML OBJKT: Applying CSP to all html files in zip, not just index.html

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -6,14 +6,20 @@ export async function prepareFilesFromZIP(buffer) {
   // unzip files
   let files = await unzipBuffer(buffer)
 
-  // inject CSP meta tag
+  // save raw index file
   const indexBlob = files['index.html']
   files['index_raw.html'] = new Blob([indexBlob], { type: indexBlob.type })
-  const indexBuffer = await indexBlob.arrayBuffer()
-  const safeIndexBuffer = injectCSPMetaTagIntoBuffer(indexBuffer)
-  files['index.html'] = new Blob([safeIndexBuffer], {
-    type: indexBlob.type,
-  })
+
+  // inject CSP meta tag in all html files
+  for (let k in files) {
+    if (k.endsWith('.html') || k.endsWith('.htm')) {
+      const pageBuffer = await files[k].arrayBuffer()
+      const safePageBuffer = injectCSPMetaTagIntoBuffer(pageBuffer)
+      files[k] = new Blob([safePageBuffer], {
+        type: indexBlob.type,
+      })
+    }
+  }
 
   // reformat
   files = Object.entries(files).map((file) => {


### PR DESCRIPTION
Reported here: #482

Currently only the main index.html file gets the CSP meta tag injected. Should be on all html pages!