### PR TITLE
Directly link to users' collection via `/tz/:id/:collection`

### DIFF
--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -39,6 +39,12 @@ export default class Display extends Component {
   componentWillMount = async () => {
     this.context.setPath(window.location.pathname)
 
+    if (window.location.pathname.split('/')[3] === "collection") {
+      this.setState( {collectionState: true, creationsState: false })
+    } else {
+      this.setState( {collectionState: false, creationsState: true })
+    }
+
     await GetUserMetadata(this.state.wallet).then((data) => {
       if (data.data.alias) this.setState({ alias: data.data.alias })
       if (data.data.description)

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -115,11 +115,15 @@ export default class Display extends Component {
       })
   }
 
-  creations = () =>
+  creations = () => {
     this.setState({ collectionState: false, creationsState: true })
+    this.props.history.push(`/tz/${this.state.wallet}`)
+  }
 
-  collection = () =>
+  collection = () => {
     this.setState({ collectionState: true, creationsState: false })
+    this.props.history.push(`/tz/${this.state.wallet}/collection`)
+  }
 
   render() {
     return (

--- a/src/routes.js
+++ b/src/routes.js
@@ -30,7 +30,7 @@ export const routes = [
   },
   {
     exact: false,
-    path: '/tz/:id',
+    path: '/tz/:id/:collection?',
     component: Display,
   },
   {


### PR DESCRIPTION
* Allow users to link directly to their collection with `/tz/:id/collection`
* Tabs onClick sets appropriate uri
* Default path is creations.

Implements https://github.com/hicetnunc2000/hicetnunc/issues/427