### PR TITLE
Removing unsupported frame-ancestors and webrtc-src rules from CSP

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -132,8 +132,6 @@ export function injectCSPMetaTagIntoHTML(html) {
     'afterbegin',
     `
     <meta http-equiv="Content-Security-Policy" content="
-    frame-ancestors
-      *;
     upgrade-insecure-requests;
     default-src
       'none';
@@ -209,8 +207,6 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://fonts.googleapis.com/
       https://ipfs.io/
       https://gateway.pinata.cloud/;
-    webrtc-src
-      *;
     worker-src
       'self'
       'unsafe-inline'


### PR DESCRIPTION
Currently these warnings are thrown in the web console for all HTML OBJKTs due to some CSP rules that are not valid / supported yet:

![unknown](https://user-images.githubusercontent.com/111979/115955976-677da980-a4fa-11eb-8317-3a7e439a94de.png)

This PR removes `frame-ancestors` and webrtc-src` rules to get rid of the messages.

If and when `webrtc-src` is supported by browsers, it can be added back.