### PR TITLE
fix(): update beacon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@airgap/beacon-sdk": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.2.4.tgz",
-      "integrity": "sha512-2TRZTOCCA9Dz0mWjZu0RKxTLVYdL5KkVpg+ULG02CVXKS/l048T2vJ2VkxGmZkkhxzJ3ER6tYBUiM8+TBRkERA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-2.2.5.tgz",
+      "integrity": "sha512-4DNh4aPl92+zFD/E5dC4WgAGYOjcJnSxzkBiQGR/oW74GTJe6hL9p0TBnJFqp5fHnqjBQSjT1zQmXG5TIZ3efw==",
       "requires": {
         "@types/chrome": "0.0.115",
         "@types/libsodium-wrappers": "0.7.7",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@airgap/beacon-sdk": "^2.2.0",
+    "@airgap/beacon-sdk": "^2.2.5",
     "@babel/core": "^7.13.16",
     "@taquito/beacon-wallet": "^8.1.1",
     "@taquito/taquito": "^8.0.6-beta.0",


### PR DESCRIPTION
Beacon SDK v2.2.5 contains a hotfix for an issue that prevents some users from connecting their P2P wallet (Kukai and AirGap).