### PR TITLE
Add OBJKT display error handling 

### DIFF
--- a/src/data/api.js
+++ b/src/data/api.js
@@ -120,7 +120,7 @@ export const GetOBJKT = async ({ id }) => {
       .then((res) => {
         resolve(res.data.result)
       })
-      .catch((e) => reject(e)) // TODO: send error message to context. have an error component to display the error
+      .catch((e) => reject(e))
   })
 }
 

--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -42,8 +42,21 @@ export const ObjktDisplay = () => {
 
         setLoading(false)
       }
-    })
-  }, [])
+    }).catch(e => {
+          if (e.response && e.response.data.error) {
+            setError(`(http ${e.response.data.error.http_status}) ${e.response.data.error.message}`)
+          } else if (e.response && e.response.data) {
+            setError(`(http ${e.response.status}) ${e.response.data}`)
+          } else if (e.request) {
+            setError(`There's a problem loading this OBJKT. Please report it on Github. ${e.message}`)
+          } else {
+            setError(`There's a problem loading this OBJKT. Please report it on Github. ${e}`)
+          }
+          setLoading(false)
+        }
+      )   
+    }
+  , [])
 
   const Tab = TABS[tabIndex].component
 


### PR DESCRIPTION
Shows error message from HEN API if OBJKT blocked. The 500 error is returned as HTML for some reason by the API, but its content is useful for debugging. The code will also handle a proposed JSON error object being returned in the format `{"error": { "http_status": 400, "message": "Invalid parameter foo"}}` as more error handling is going to be added to the API.

410 error: 

![image](https://user-images.githubusercontent.com/510285/116321084-59a57e00-a7b1-11eb-8431-27249707a7b9.png)


500 error:

![image](https://user-images.githubusercontent.com/510285/116321017-3a0e5580-a7b1-11eb-8cd7-1ff36ff7da8a.png)
