### PR TITLE
Removing "scrolling" attribute from HTML OBJKT display iframes

### DIFF
--- a/src/components/media-types/html/index.js
+++ b/src/components/media-types/html/index.js
@@ -148,7 +148,6 @@ export const HTMLComponent = ({
         src={`${src}?creator=${_creator_}&viewer=${_viewer_}`}
         sandbox="allow-scripts allow-same-origin"
         allow="accelerometer; camera; gyroscope; microphone; xr-spatial-tracking;"
-        scrolling="no"
       />
     </div>
   )


### PR DESCRIPTION
The `scrolling="no"` attribute is present on HTML OBJKT display iframes, which prevents creators from enabling any kind of scrolling.

This PR simply removes this attribute.