### PR TITLE
Bugs: filter was inverted and tags need encodeURI

### DIFF
--- a/src/components/tags/index.js
+++ b/src/components/tags/index.js
@@ -7,10 +7,10 @@ export const Tags = ({ tags }) => {
   return (
     <div className={styles.container}>
       {tags
-        .filter((e) => e === '')
+        .filter((e) => e !== '')
         .map((tag, index) => {
           return (
-            <Button key={`tag${tag}${index}`} to={`${PATH.TAGS}/${tag}`}>
+            <Button key={`tag${tag}${index}`} to={`${PATH.TAGS}/${encodeURI(tag)}`}>
               <div className={styles.tag}>{tag}</div>
             </Button>
           )


### PR DESCRIPTION
1) The filter condition was inverted, it tries to filter out empty strings.
2) The tag is used as a URL and thus characters like '%' need to be URI encoded
Example that is currently broken in production: https://www.hicetnunc.xyz/objkt/29855
as the objkt contains a tag "96%biomass"
Noted already as: https://github.com/hicetnunc2000/hicetnunc/issues/662