### PR TITLE
Hotfix for broken HTML OBJKTs thumbnail images

### DIFF
--- a/src/components/media-types/index.js
+++ b/src/components/media-types/index.js
@@ -61,11 +61,8 @@ export const renderMediaType = (props) => {
         url = getInfuraUrl(path)
       }
       let displayUri = ''
-      if (metadata && metadata.token_info && metadata.token_info.displayUri) {
-        displayUri = metadata.token_info.displayUri.replace(
-          'ipfs://',
-          CLOUDFLARE
-        )
+      if (metadata && metadata.display_uri) {
+        displayUri = metadata.display_uri.replace('ipfs://', CLOUDFLARE)
       }
       return (
         <Container interactive={interactive}>


### PR DESCRIPTION
It seems the thumbnails for HTML OBJKTs broke somewhere along the way:

![Screen Shot 2021-05-12 at 1 52 52 PM](https://user-images.githubusercontent.com/111979/117970854-74d3ca00-b329-11eb-92ba-c24328ee935b.png)

This is a simple fix for that.

![Screen Shot 2021-05-12 at 1 53 13 PM](https://user-images.githubusercontent.com/111979/117970875-7b624180-b329-11eb-9f1f-2f71dd1dc93a.png)


