### PR TITLE
hDAO tooltip and layout changed on item-info component

### DIFF
--- a/src/components/item-info/index.js
+++ b/src/components/item-info/index.js
@@ -74,7 +74,7 @@ export const ItemInfo = ({
   const renderHDAObutton = (id, balance) => {
     return (
       <Button onClick={() => curateOrClaim(id, balance)}>
-        <Primary>〇{balance ? ` ${hDAO_balance}` : ''}</Primary>
+        <Primary><span className={styles.top} data-position={'top'} data-tooltip={'curate'}>〇</span>{balance ? ` ${hDAO_balance}` : ''}</Primary>
       </Button>
     )
   }
@@ -108,22 +108,23 @@ export const ItemInfo = ({
             </div>
           )}
         </div>
-      </div>
-
-      <div className={styles.container}>
-        {isDetailView ? (
-          <p>OBJKT#{token_id}</p>
-        ) : (
-          <Button to={`${PATH.OBJKT}/${token_id}`} disabled={isDetailView}>
-            <Primary>OBJKT#{token_id}</Primary>
-          </Button>
+        {feed && (
+          <div className={styles.objktContainer}>
+            <Button to={`${PATH.OBJKT}/${token_id}`} disabled={isDetailView}>
+              <Primary>OBJKT#{token_id}</Primary>
+            </Button>
+            <div style={{ paddingLeft: '20px', marginBottom: '2px' }}>{renderHDAObutton(token_id, hDAO_balance)}</div>
+          </div>
         )}
-        {feed ? (
-          <div>{renderHDAObutton(token_id, hDAO_balance)}</div>
-        ) : (
-          <Button onClick={() => handleCollect()}>
-            <Purchase>{message}</Purchase>
-          </Button>
+      </div>
+      <div className={styles.container}>
+        {isDetailView && (
+          <div className={styles.container}>
+            <p>OBJKT#{token_id}</p>
+            <Button onClick={() => handleCollect()}>
+              <Purchase>{message}</Purchase>
+            </Button>
+          </div>
         )}
       </div>
       <div className={styles.container}>

--- a/src/components/item-info/styles.module.scss
+++ b/src/components/item-info/styles.module.scss
@@ -3,6 +3,14 @@
   align-items: center;
   justify-content: space-between;
   padding-top: 10px;
+  word-break: normal;
+  width: 100%;
+}
+
+.objktContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .edition {
@@ -16,4 +24,107 @@
     display: flex;
     align-items: center;
   }
+}
+
+span[data-tooltip].top {
+	&:before,
+	&:after {
+		transform: translateY(10px);
+	}
+	
+	&:hover:after,
+	&:hover:before {
+		transform: translateY(0px);
+	}
+}
+
+span[data-tooltip].right {
+	&:before,
+	&:after {
+		transform: translateX(0px);
+	}
+	
+	&:hover:after,
+	&:hover:before {
+		transform: translateX(10px);
+	}
+}
+
+span[data-tooltip].bottom {
+	&:before,
+	&:after {
+		transform: translateY(-10px);
+	}
+	
+	&:hover:after,
+	&:hover:before {
+		transform: translateY(0px);
+	}
+}
+
+span[data-tooltip].left {
+	&:before,
+	&:after {
+		transform: translateX(0px);
+	}
+	
+	&:hover:after,
+	&:hover:before {
+		transform: translateX(-10px);
+	}
+}
+
+span[data-tooltip] {
+	position: relative;
+
+	&:after,
+	&:before {
+		position: absolute;
+		visibility: hidden;
+		opacity: 1;
+		transition: transform 200ms ease, opacity 200ms;
+		z-index: 99;
+	}
+
+	&:before {
+		content: attr(data-tooltip);
+    background-color: var(--text-color);
+		color: var(--background-color);
+		font-size: 12px;
+		font-weight: bold;
+		padding: 10px 15px;
+		border-radius: 10px;
+		white-space: nowrap;
+		text-decoration: none;
+		letter-spacing: 1px;
+	}
+
+	&:after {
+		width: 0;
+		height: 0;
+		border: 6px solid transparent;
+		content: '';
+	}
+
+	&:hover:after,
+	&:hover:before {
+		visibility: visible;
+		opacity: 1;
+		transform: translateY(0px);
+	}
+}
+
+// top tooltip
+span[data-tooltip][data-position="top"]:before {
+	bottom: 100%;
+	left: -195%;
+	margin-bottom: 9px;
+}
+
+span[data-tooltip][data-position="top"]:after {
+	border-top-color: var(--text-color);;
+	border-bottom: none;
+	bottom: 101%;
+	left: calc(50% - 6px);
+	margin-bottom: 4px;
 }

--- a/src/components/loading/styles.module.scss
+++ b/src/components/loading/styles.module.scss
@@ -14,6 +14,7 @@
 .container {
   display: flex;
   align-items: center;
+  justify-content: center;
 
   .circle {
     display: inline-block;


### PR DESCRIPTION
- centered the loading circle
- tooltip on the hDAO circle on item-feed and objkt view
- item-feed component has some things switched around so it follows these formats in the pictures from the figma:
![Screen Shot 2021-05-17 at 5 19 25 PM](https://user-images.githubusercontent.com/8921838/118558005-08dfd000-b734-11eb-88fe-bca043b70f3d.png)

and this one for objkt view (need to add the avatar later):
![Screen Shot 2021-05-17 at 5 20 55 PM](https://user-images.githubusercontent.com/8921838/118558164-3fb5e600-b734-11eb-8cba-628d243bf6df.png)

_(the hdao stays on the left in the objkt view per rafa's request)_

