### PR TITLE
GLB: Enable iOS AR

### DIFF
--- a/src/components/media-types/glb/index.js
+++ b/src/components/media-types/glb/index.js
@@ -17,6 +17,7 @@ export const GLBComponent = ({ src, interactive }) => {
 
   if (interactive) {
     props['ar'] = true
+    props['ar-modes'] = 'webxr scene-viewer quick-look'
     props['camera-controls'] = true
   }
 


### PR DESCRIPTION
[`<model-viewer>` 1.7.0 now support iOS AR](https://twitter.com/modelviewer/status/1394331032283795460) but it needs an additional property.