### PR TITLE
[please test/review] point production to latest API URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,11 @@
 # production
-REACT_APP_FEED='https://1xgf1e26jb.execute-api.us-east-1.amazonaws.com/dev/feed'
-REACT_APP_FEED_HDAO='https://1xgf1e26jb.execute-api.us-east-1.amazonaws.com/dev/hdao'
+REACT_APP_FEED='https://51rknuvw76.execute-api.us-east-1.amazonaws.com/dev/feed'
+REACT_APP_FEED_HDAO='https://51rknuvw76.execute-api.us-east-1.amazonaws.com/dev/hdao'
 REACT_APP_TZ='https://51rknuvw76.execute-api.us-east-1.amazonaws.com/dev/tz'
-REACT_APP_OBJKT='https://1xgf1e26jb.execute-api.us-east-1.amazonaws.com/dev/objkt'
-REACT_APP_RANDOM='https://1xgf1e26jb.execute-api.us-east-1.amazonaws.com/dev/random'
-REACT_APP_FEATURED='https://1xgf1e26jb.execute-api.us-east-1.amazonaws.com/dev/featured'
-REACT_APP_REC_CURATE='https://1xgf1e26jb.execute-api.us-east-1.amazonaws.com/dev/recommend_curate'
+REACT_APP_OBJKT='https://51rknuvw76.execute-api.us-east-1.amazonaws.com/dev/objkt'
+REACT_APP_RANDOM='https://51rknuvw76.execute-api.us-east-1.amazonaws.com/dev/random'
+REACT_APP_FEATURED='https://51rknuvw76.execute-api.us-east-1.amazonaws.com/dev/featured'
+REACT_APP_REC_CURATE='https://51rknuvw76.execute-api.us-east-1.amazonaws.com/dev/recommend_curate'
 REACT_APP_TAGS='https://vj4pzbqrsa.execute-api.us-east-1.amazonaws.com/dev/tag'
 REACT_APP_SUBJKT='https://vj4pzbqrsa.execute-api.us-east-1.amazonaws.com/dev/subjkt'
 # localhost running API


### PR DESCRIPTION
Rafael only updated the URL for the 'tz' link, which left other areas still open to exploitation:

https://github.com/hicetnunc2000/hicetnunc/commit/4a5b6a7b4aace9e3dd95a6c7429d984c5a762ef1#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055d

This patch updates all the API endpoints to the latest.

Note: I am not well versed enough with the architecture of the backend/frontend to know if this is a good idea; perhaps Rafael had a reason for only updating the 'tz' endpoint and not the others. I also don't know where these API URLs are coming from but I do know the '51rknuvw76' endpoint blocks the endpoint for now due to https://github.com/hicetnunc2000/hicetnunc-api/pull/75. 

Please test / review before merging...
