### PR TITLE
mobile breakpoint padding on item display

### DIFF
--- a/src/components/layout/padding/styles.module.scss
+++ b/src/components/layout/padding/styles.module.scss
@@ -1,4 +1,14 @@
+@import '../../../styles/variables.scss';
+@import '../../../styles/layout.scss';
+
 .container {
-  padding: 0 20px;
   // border: 1px dashed green;
+
+  @include respond-to('phone') {
+    padding: 0 10px;
+  }
+
+  @include respond-to('tablet') {
+    padding: 0 20px;
+  }
 }


### PR DESCRIPTION
10px padding instead of 20px on mobile to fix spacing issue, especially when objkts reach 100,000

![hen1](https://user-images.githubusercontent.com/8921838/119387064-65903d00-bc96-11eb-87c5-3454d5721cc1.png)


FIX:
![hen2](https://user-images.githubusercontent.com/8921838/119387125-7fca1b00-bc96-11eb-9332-fc42115bd42b.png)


