### PR TITLE
reverse title to "{title} - hic et nunc"

### DIFF
--- a/src/components/layout/page/index.js
+++ b/src/components/layout/page/index.js
@@ -13,7 +13,7 @@ export const Page = ({ title = 'hic et nunc', children = null, large }) => {
     <main className={classes}>
       <Helmet>
         {title !== '' ? (
-          <title>hic et nunc - {title}</title>
+          <title>{title} - hic et nunc</title>
         ) : (
           <title>hic et nunc</title>
         )}


### PR DESCRIPTION
proposal to switch from: "hic et nunc - {title}" to "{title} - hic et nunc" to make browser tabs easier to navigate.
Fixes this problem when you have lots of tabs:
![image](https://user-images.githubusercontent.com/26558614/120083327-ccd63480-c07c-11eb-8e2d-8d7778732716.png)
After:
![image](https://user-images.githubusercontent.com/26558614/120083410-60a80080-c07d-11eb-9517-14c5fdfffba7.png)

