### PR TITLE
clickable pdfs

### DIFF
--- a/src/components/media-types/index.js
+++ b/src/components/media-types/index.js
@@ -28,6 +28,7 @@ export const renderMediaType = (props) => {
     interactive = false,
     preview = false,
     metadata,
+    pdfscroll = true
   } = props
   const path = uri
   let url = preview ? uri : `${CLOUDFLARE}${path}`
@@ -118,7 +119,7 @@ export const renderMediaType = (props) => {
     case MIMETYPE.PDF:
       return (
         <Container interactive={interactive}>
-          <PdfComponent src={url} />
+          <PdfComponent src={url} pdfscroll={pdfscroll} />
         </Container>
       )
     default:

--- a/src/components/media-types/pdf/index.js
+++ b/src/components/media-types/pdf/index.js
@@ -1,12 +1,16 @@
 import React from 'react'
 import styles from './styles.module.scss'
 
-export const PdfComponent = ({ src }) => (
+export const PdfComponent = ({ src, pdfscroll = true }) => {
+  const iframeClass = pdfscroll?'':styles.noscroll
+  return (
   <div className={styles.container}>
     <iframe
       title="hic et nunc PDF renderer"
       src={`${src}#zoom=50`}
       scrolling="no"
+      className={iframeClass}
     />
   </div>
-)
+  )
+}

--- a/src/components/media-types/pdf/styles.module.scss
+++ b/src/components/media-types/pdf/styles.module.scss
@@ -22,3 +22,7 @@
     border: none;
   }
 }
+
+.noscroll {
+  pointer-events: none;
+}

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -445,6 +445,7 @@ export default class Display extends Component {
                         mimeType,
                         uri: uri.split('//')[1],
                         metadata: nft,
+                        pdfscroll: false
                       })}
                     </div>
                   </Button>
@@ -469,6 +470,7 @@ export default class Display extends Component {
                         mimeType,
                         uri: uri.split('//')[1],
                         metadata: nft,
+                        pdfscroll: false
                       })}
                     </div>
                   </Button>

--- a/src/pages/tags/index.js
+++ b/src/pages/tags/index.js
@@ -83,6 +83,7 @@ export const Tags = () => {
                         mimeType,
                         uri: uri.split('//')[1],
                         metadata: nft,
+                        pdfscroll: false
                       })}
                       <div className={styles.number}>OBJKT#{nft.token_id}</div>
                     </div>


### PR DESCRIPTION
fix #763 by setting 'pointer-events: none' on pdf viewer in feeds. 

this creates a somewhat unnatural UI where you can't scroll the pdf viewer until you go to the objkt page, but fixes the current huge issue of objkts being inaccessible through the UI. long term solution is a preview image.