### PR TITLE
video loading=lazy

### DIFF
--- a/src/components/media-types/video/index.js
+++ b/src/components/media-types/video/index.js
@@ -71,6 +71,7 @@ export const VideoComponent = ({ src, interactive, inView }) => {
         loop
         controls={interactive}
         src={src}
+        loading="lazy"
       />
     </div>
   )


### PR DESCRIPTION
adds `loading="lazy"` to video render element. [Browser support 70%](https://caniuse.com/loading-lazy-attr), fallback behavior for other browsers is the current behavior.
In testing on a large collection this sped up the above-the-fold load time noticeably, and reduced initial page load by half a gigabyte. 
![image_614](https://user-images.githubusercontent.com/26558614/120261242-57b95980-c24c-11eb-9e21-66da8748752a.png)

Tested on windows chrome/brave, might be worth browser testing.