### PR TITLE
Add services.tzkt.io to the CSP

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -152,6 +152,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       'unsafe-inline'
       data:
       blob:
+      https://services.tzkt.io
       https://ipfs.infura.io
       https://cloudflare-ipfs.com/
       https://ipfs.io/


### PR DESCRIPTION
Requesting PR to include https://services.tzkt.io in the CSP, under the 'img-src/blob' definition
to allow Interactive OBJKTs to load images such as users avatars stored on site.