### PR TITLE
OBJKT Width display on High-density pixel screens

### DIFF
--- a/src/pages/objkt-display/styles.module.scss
+++ b/src/pages/objkt-display/styles.module.scss
@@ -40,7 +40,7 @@
   align-items: center;
 
   @include respond-to('desktop') {
-    width: 60vh;
+    width: 38vw;
   }
 
   > div {


### PR DESCRIPTION
Requesting a PR to allow a unified display of objects across various screen resolutions; while keeping as much information as possible visible underneath the object preview.
Using the a 'vw' derivative for the width, creates a similar layout // look-n-feel, if viewed on either conventional pixel density displays or retina. Currently the object preview appears rather small on retina displays, and it mostly affecting video and static image artworks which are horizontal and specially interactive objects which require the user to navigate/use the artwork. Thank you.

Current display, on retina
![image](https://user-images.githubusercontent.com/42539219/122408383-04087900-cf8b-11eb-930c-d790d4f726bd.png)

Retina using 36vw
![image](https://user-images.githubusercontent.com/42539219/122408477-18e50c80-cf8b-11eb-861b-88de6552f277.png)

1920x1200 , using 36vw
![image](https://user-images.githubusercontent.com/42539219/122408597-31552700-cf8b-11eb-9c8f-27dea14597a5.png)

The last two are very similar, although viewed in much different resolutions.
