### PR TITLE
Use "extra" displayUri information on Collection/Creation

### DIFF
--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -3,7 +3,7 @@ import { Button, Primary } from '../../components/button'
 import { HicetnuncContext } from '../../context/HicetnuncContext'
 import { Page, Container, Padding } from '../../components/layout'
 import { Loading } from '../../components/loading'
-import { renderMediaType } from '../../components/media-types'
+import { renderThumbnail } from '../../components/media-types'
 import { Identicon } from '../../components/identicons'
 import { walletPreview } from '../../utils/string'
 import { SanitiseOBJKT, SanitizeDipDup } from '../../utils/sanitise'
@@ -49,6 +49,7 @@ query collectorGallery($address: String!) {
       creator {
         address
       }
+      extra
     }
   }
 }
@@ -97,6 +98,7 @@ query creatorGallery($address: String!) {
         tag
       }
     }
+    extra
   }
 }
 `
@@ -618,14 +620,16 @@ export default class Display extends Component {
             >
               <ResponsiveMasonry>
                 {this.state.items.map((nft) => {
+                  console.log('NFT Creation', nft)
                   return (
                     <Button key={nft.id} to={`${PATH.OBJKT}/${nft.id}`}>
                       <div className={styles.container}>
-                        {renderMediaType({
+                        {renderThumbnail({
                           mimeType: nft.mime,
                           artifactUri: nft.artifact_uri,
                           displayUri: nft.display_uri,
-                          displayView: true
+                          displayView: true,
+                          extra: nft.extra
                         })}
                       </div>
                     </Button>
@@ -653,15 +657,16 @@ export default class Display extends Component {
             >
               <ResponsiveMasonry>
                 {this.state.items.map((nft) => {
-                  console.log(nft)
+                  console.log('NFT Collection', nft)
                   return (
                     <Button key={nft.token.id} to={`${PATH.OBJKT}/${nft.token.id}`}>
                       <div className={styles.container}>
-                        {renderMediaType({
+                        {renderThumbnail({
                           mimeType: nft.token.mime,
                           artifactUri: nft.token.artifact_uri,
                           displayUri: nft.token.display_uri,
-                          displayView: true
+                          displayView: true,
+                          extra: nft.token.extra
                         })}
                       </div>
                     </Button>


### PR DESCRIPTION
Extra display URIs have been generated and added to IPFS. These are JPEGs of 128, 512 and 1024 width, GIFs for files that were smaller than 100kb, and 15 FPS, 15 second, MP4s for larger GIFs and videos

These are stored in the "extra" field in Hicdex GraphQL response.

This is an exploration of using this only display still images in collectin/creation tabs, as for those with larger collections it will kill the browser. It will fall back to artifiact / display URIs for those that are missing.

It probably needs a few more additions before it goes live:

- allow users to choose a "low bandwidth mode" which only shows images / smaller images
- add this functionality to feed / random etc
- display an indicator, like the one used for HTML, over thumbnails to show it is a video, GIF, 3D etc.

We also need to work out a solution to create these for every type that is uploaded.