### PR TITLE
Change default storage to prevent backtracks

### DIFF
--- a/src/context/HicetnuncContext.js
+++ b/src/context/HicetnuncContext.js
@@ -104,7 +104,7 @@ class HicetnuncContextProviderClass extends Component {
         let batch = await Tezos.wallet.batch().withContractCall(objkts.methods.update_operators([{ add_operator: { operator: this.state.v2, token_id: parseFloat(objkt_id), owner: from } }]))
         .withContractCall(marketplace.methods.swap(creator, parseFloat(objkt_amount), parseFloat(objkt_id), parseFloat(royalties), parseFloat(xtz_per_objkt)))
 
-        return await batch.send()
+        return await batch.send({ storageLimit: 209 })
       },
 
       batch_cancel: async (arr) => {

--- a/src/context/HicetnuncContext.js
+++ b/src/context/HicetnuncContext.js
@@ -104,7 +104,7 @@ class HicetnuncContextProviderClass extends Component {
         let batch = await Tezos.wallet.batch().withContractCall(objkts.methods.update_operators([{ add_operator: { operator: this.state.v2, token_id: parseFloat(objkt_id), owner: from } }]))
         .withContractCall(marketplace.methods.swap(creator, parseFloat(objkt_amount), parseFloat(objkt_id), parseFloat(royalties), parseFloat(xtz_per_objkt)))
 
-        return await batch.send({ storageLimit: 209 })
+        return await batch.send({ storageLimit: 350, mutez: true })
       },
 
       batch_cancel: async (arr) => {


### PR DESCRIPTION
Default storage was not set within the v2 swaps function, adding ```{ storageLimit: 209 }``` to the ```.send()``` function sets the default storage to 209 (the most storage that has been used with swaps AFAIK) instead of the default. 