### PR TITLE
Page title fix!

### DIFF
--- a/src/components/layout/page/index.js
+++ b/src/components/layout/page/index.js
@@ -4,21 +4,20 @@ import classnames from 'classnames'
 import { VisuallyHidden } from '../../visually-hidden'
 import styles from './styles.module.scss'
 
-export const Page = ({ title = 'hic et nunc', children = null, large }) => {
+export const Page = ({ title = '', children = null, large }) => {
   const classes = classnames({
     [styles.container]: true,
     [styles.large]: large,
   })
+
+  const displayTitle = (title == '') ? 'hic et nunc' : title + ' - hic et nunc';
+
   return (
     <main className={classes}>
       <Helmet>
-        {title !== '' ? (
-          <title>{title} - hic et nunc</title>
-        ) : (
-          <title>hic et nunc</title>
-        )}
+        <title>{displayTitle}</title>
       </Helmet>
-      <VisuallyHidden as="h1">{title}</VisuallyHidden>
+      <VisuallyHidden as="h1">{title || 'hic et nunc'}</VisuallyHidden>
       {children}
     </main>
   )

--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -83,7 +83,7 @@ export const ObjktDisplay = () => {
   const Tab = TABS[tabIndex].component
 
   return (
-    <Page title={nft?.name}>
+    <Page title={nft?.title}>
       {loading && (
         <Container>
           <Padding>


### PR DESCRIPTION
Fix the 'hic et nunc - hic et nunc' titles so they actually reflect the objkt's title. A little slice of https://github.com/hicetnunc2000/hicetnunc/pull/987 :) 

Also, on the visually-hidden H1, I assumed that should just be the objkt's name, if present. the h1 seems to be for accessibility's sake, so that's what that's about. 