### PR TITLE
Multiline description display support

### DIFF
--- a/src/pages/objkt-display/tabs/info.js
+++ b/src/pages/objkt-display/tabs/info.js
@@ -27,7 +27,9 @@ export const Info = ( token_info ) => {
       </Container>
 
       <Container>
-        <Padding>{description}</Padding>
+        <Padding>
+          <div style={{ whiteSpace: 'pre-wrap' }}>{description}</div>
+        </Padding>
       </Container>
 
       <Container>


### PR DESCRIPTION
adds css whitespace pre-wrap around description to render \n\n as linebreaks