### PR TITLE
Feature/header profile action

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -37,27 +37,21 @@ export const Header = () => {
   }
 
   // we assume user isn't connected
-  let profileButton = (
-    <Button onClick={()=>context.syncTaquito()} secondary>
-      <Primary>sync</Primary>
-    </Button>
-  )
+  let headerButtonHandler = () => context.syncTaquito()
+  let headerButtonText = 'sync'
 
-  // but if they are, we add shortcut to their profile
+  // but if they are
   if (context.acc?.address) {
-    profileButton = (
-      <Button onClick={() => handleRoute('/sync', 'tz')} secondary>
-        <Primary>{walletPreview(context.acc.address)}</Primary>
-      </Button>
-    )
+    // is menu closed?
+    if (context.collapsed) {
+      headerButtonHandler = () => handleRoute('/sync', 'tz')
+      headerButtonText = walletPreview(context.acc.address)
+    } else {
+      // menu is open
+      headerButtonHandler = () => context.disconnect()
+      headerButtonText = 'unsync'
+    }
   }
-
-  // ... and show additional unsync button when menu opens
-  const unSyncButton = context.acc?.address && !context.collapsed ? (
-    <Button onClick={()=>context.disconnect()} secondary>
-      <Primary>unsync</Primary>
-    </Button>
-  ) : ''
 
   return (
     <>
@@ -137,8 +131,9 @@ export const Header = () => {
           </Button>
 
           <div className={styles.right}>
-            {unSyncButton}
-            {profileButton}
+            <Button onClick={headerButtonHandler} secondary>
+              <Primary>{headerButtonText}</Primary>
+            </Button>
 
             <Button onClick={context.toogleNavbar} secondary>
               <VisuallyHidden>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -29,20 +29,6 @@ export const Header = () => {
     context.setTheme(getItem('theme') || setItem('theme', 'dark'))
   }, [])
 
-  // we assume user isn't connected
-  let button = 'sync'
-
-  // but if they are
-  if (context.acc?.address) {
-    // is menu closed?
-    if (context.collapsed) {
-      button = walletPreview(context.acc.address)
-    } else {
-      // menu is open
-      button = 'unsync'
-    }
-  }
-
   //const activeAccount = await wallet.client.getActiveAccount()
   //console.log(activeAccount)
   const handleRoute = (path, data) => {
@@ -50,15 +36,28 @@ export const Header = () => {
     history.push(path, data)
   }
 
-  const handleSyncUnsync = () => {
-    if (context.acc?.address && !context.collapsed) {
-      // disconnect wallet
-      context.disconnect()
-    } else {
-      // connect wallet
-      context.syncTaquito()
-    }
+  // we assume user isn't connected
+  let profileButton = (
+    <Button onClick={()=>context.syncTaquito()} secondary>
+      <Primary>sync</Primary>
+    </Button>
+  )
+
+  // but if they are, we add shortcut to their profile
+  if (context.acc?.address) {
+    profileButton = (
+      <Button onClick={() => handleRoute('/sync', 'tz')} secondary>
+        <Primary>{walletPreview(context.acc.address)}</Primary>
+      </Button>
+    )
   }
+
+  // ... and show additional unsync button when menu opens
+  const unSyncButton = context.acc?.address && !context.collapsed ? (
+    <Button onClick={()=>context.disconnect()} secondary>
+      <Primary>unsync</Primary>
+    </Button>
+  ) : ''
 
   return (
     <>
@@ -138,9 +137,8 @@ export const Header = () => {
           </Button>
 
           <div className={styles.right}>
-            <Button onClick={handleSyncUnsync} secondary>
-              <Primary>{button}</Primary>
-            </Button>
+            {unSyncButton}
+            {profileButton}
 
             <Button onClick={context.toogleNavbar} secondary>
               <VisuallyHidden>

--- a/src/components/header/styles.module.scss
+++ b/src/components/header/styles.module.scss
@@ -47,12 +47,9 @@
         display: flex;
         align-items: center;
         font-size: 16px;
-      }
-
-      .hamburger {
-        width: 30px;
-        height: auto;
-        margin-left: 10px;
+        + * {
+          margin-left: 10px;
+        }
       }
     }
   }

--- a/src/components/icons/styles.module.scss
+++ b/src/components/icons/styles.module.scss
@@ -1,9 +1,6 @@
 @import '../../styles/variables.scss';
 
 .menu {
-  margin-left: 6px;
-  // border: 1px dashed black;
-
   svg {
     display: block;
     width: 30px;


### PR DESCRIPTION
I regularly click the wallet preview expecting to goto my profile, but nothing happens. Hovering makes it look like a link, so it feels odd that nothing happens.

This PR links the wallet preview to the profile page of the synced wallet. I have decoupled the unsync from the profile button. Instead it now exists as a separate button to the left of the wallet preview when the menu is opened.

Removed some CSS that didnt seem to be used anywhere whilst I was here (`.hamburger` code).

<img width="1079" alt="Screen Shot 2021-07-10 at 11 25 10 pm" src="https://user-images.githubusercontent.com/1259367/125164536-21211800-e1d6-11eb-8872-c33052cb7d58.png">


