### PR TITLE
line breaks on mint preview

### DIFF
--- a/src/components/preview/styles.module.scss
+++ b/src/components/preview/styles.module.scss
@@ -16,6 +16,10 @@
     margin-top: 20px;
   }
 
+  .description {
+    white-space: pre-wrap;
+  }
+
   @include respond-to('tablet') {
     flex-direction: initial;
 


### PR DESCRIPTION
preview component needs white-space: pre-wrap to match objkt-display