### PR TITLE
Make /v1 single swap cancel point to v1 contract

### DIFF
--- a/src/context/HicetnuncContext.js
+++ b/src/context/HicetnuncContext.js
@@ -389,6 +389,18 @@ class HicetnuncContextProviderClass extends Component {
           )
       },
 
+      cancelv1: async (swap_id) => {
+        console.log(swap_id)
+        return await Tezos.wallet
+          .at(this.state.v1)
+          .then((c) =>
+            c.methods
+              .cancel_swap(parseFloat(swap_id))
+              .send({ amount: 0, storageLimit: 310 })
+          )
+          .catch((e) => e)
+      },
+
       cancel: async (swap_id) => {
         console.log(swap_id)
         return await Tezos.wallet

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -741,7 +741,7 @@ export default class Display extends Component {
                         <strong>{e.amount_left}x OBJKT#{e.token_id} {e.price}µtez</strong>
                       </Primary>
                     </Button>
-                    <Button onClick={() => this.context.cancel(e.id)}>
+                    <Button onClick={() => this.context.cancelv1(e.id)}>
                       Cancel Swap
                     </Button>
                   </Padding>


### PR DESCRIPTION
Single cancel on the /v1 endpoint was pointing to v2 contract in the context. This makes it use a new v1 version (`cancelv1`)

Partially fixes #992 