### PR TITLE
Change price of swapped edition

### DIFF
--- a/src/components/owner-swaps/index.js
+++ b/src/components/owner-swaps/index.js
@@ -7,9 +7,9 @@ const sortByPrice = (a, b) => {
   return Number(a.xtz_per_objkt) - Number(b.xtz_per_objkt)
 }
 
-export const OwnerSwaps = ({ swaps, handleCollect, acc, cancel }) => {
-  swaps = swaps.filter(e => parseInt(e.contract_version) === 2 && parseInt(e.status) === 0 && e.is_valid )
-  console.log('v2',swaps)
+export const OwnerSwaps = ({ swaps, handleCollect, acc, cancel, reswapv2 }) => {
+  swaps = swaps.filter(e => parseInt(e.contract_version) === 2 && parseInt(e.status) === 0 && e.is_valid)
+  console.log('v2', swaps)
   return (
     <div className={styles.container}>
       {swaps.sort(sortByPrice).map((swap, index) => {
@@ -36,10 +36,17 @@ export const OwnerSwaps = ({ swaps, handleCollect, acc, cancel }) => {
               </Button>
               {swap.creator.address ===
                 (acc !== undefined ? acc.address : '') && (
-                <Button onClick={() => cancel(swap.id)}>
-                  <Purchase>cancel</Purchase>
-                </Button>
-              )}
+                  <>
+                    <Button onClick={() => cancel(swap.id)}>
+                      <Purchase>cancel</Purchase>
+                    </Button>
+                    <div className={styles.break}></div>
+                    <input id="new_price" type="text" size="12" placeholder="New price"></input>
+                    <Button onClick={() => reswapv2(swap)}>
+                      <Purchase>reswap</Purchase>
+                    </Button>
+                  </>
+                )}
             </div>
           </div>
         )

--- a/src/context/HicetnuncContext.js
+++ b/src/context/HicetnuncContext.js
@@ -44,7 +44,7 @@ const Tezos = new TezosToolkit('https://mainnet-tezos.giganode.io')
 
 function modifyFeeAndLimit(op) {
   const { fee, gas_limit, storage_limit, ...rest } = op;
-  
+
   if (op.parameters && (op.parameters.entrypoint === "swap") || (op.parameters.entrypoint === "mint_OBJKT") || (op.parameters.entrypoint === "collect")) {
     rest.storage_limit = 310
   }
@@ -160,6 +160,45 @@ class HicetnuncContextProviderClass extends Component {
           }
         ]
 
+        let batch = await Tezos.wallet.batch(list);
+        return await batch.send()
+      },
+
+      reswapv2: async (swap) => {
+        let xtz_per_objkt = document.getElementById("new_price").value
+        if (typeof (xtz_per_objkt) == 'undefined' || !xtz_per_objkt) return;
+        if (parseFloat(xtz_per_objkt) == NaN) return;
+        if (parseFloat(xtz_per_objkt) <= 0.0) return;
+
+        let objkt_id = swap.token.id
+        let creator = swap.token.creator_id
+        let from = swap.creator_id
+        let price = parseFloat(xtz_per_objkt) * 1000000
+
+        let objkts = await Tezos.wallet.at(this.state.objkts)
+        await Tezos.wallet.at(this.state.v2).then(c => console.log(c.parameterSchema.ExtractSignatures()))
+        let marketplace = await Tezos.wallet.at(this.state.v2)
+        let list = []
+        // cancel current swap
+        list.push({
+          kind: OpKind.TRANSACTION,
+          ...marketplace.methods.cancel_swap(parseFloat(swap.id)).toTransferParams({ amount: 0, mutez: true, storageLimit: 310 })
+        })
+        // swap with new price
+        list.push(
+          {
+            kind: OpKind.TRANSACTION,
+            ...objkts.methods.update_operators([{ add_operator: { operator: this.state.v2, token_id: parseFloat(objkt_id), owner: from } }])
+              .toTransferParams({ amount: 0, mutez: true, storageLimit: 100 })
+          }
+        )
+        list.push(
+          {
+            kind: OpKind.TRANSACTION,
+            ...marketplace.methods.swap(creator, parseFloat(swap.amount_left), parseFloat(objkt_id), parseFloat(swap.royalties), price).toTransferParams({ amount: 0, mutez: true, storageLimit: 250 })
+          }
+        )
+        console.log(list)
         let batch = await Tezos.wallet.batch(list);
         return await batch.send()
       },
@@ -583,7 +622,7 @@ class HicetnuncContextProviderClass extends Component {
         })
       },
 
-      /* 
+      /*
                 airgap/thanos interop methods
             */
       operationRequest: async (obj) => {

--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -56,6 +56,10 @@ swaps {
   royalties
   creator_id
   is_valid
+  token {
+    id
+    creator_id
+  }
 }
 token_holders(where: {quantity: {_gt: "0"}}) {
   holder_id
@@ -146,7 +150,7 @@ export const ObjktDisplay = () => {
         } else {
           await context.setAccount()
           setNFT(objkt)
-  
+
           setLoading(false)
         }
       })

--- a/src/pages/objkt-display/tabs/collectors.js
+++ b/src/pages/objkt-display/tabs/collectors.js
@@ -7,23 +7,23 @@ import { OwnerSwaps } from '../../../components/owner-swaps'
 const _ = require('lodash')
 
 export const Collectors = ({ owners, swaps, token_holders }) => {
-  const { syncTaquito, collect, acc, getAccount, cancel } =
+  const { syncTaquito, collect, acc, getAccount, cancel, reswapv2 } =
     useContext(HicetnuncContext)
-    console.log(swaps)
-    console.log('holders', token_holders)
+  console.log(swaps)
+  console.log('holders', token_holders)
 
   // sort swaps in ascending price order
 
   swaps = _.orderBy(swaps, 'price', 'asc')
 
-/*   const filtered =
-    (owners &&
-      Object.keys(owners)
-        .filter((s) => s.startsWith('tz'))
-        .filter((s) => parseFloat(owners[s]) > 0) // removes negative owners
-        .filter((e) => e !== 'tz1burnburnburnburnburnburnburjAYjjX') // remove burn wallet
-        .map((s) => ({ amount: owners[s], wallet: s }))) ||
-    [] */
+  /*   const filtered =
+      (owners &&
+        Object.keys(owners)
+          .filter((s) => s.startsWith('tz'))
+          .filter((s) => parseFloat(owners[s]) > 0) // removes negative owners
+          .filter((e) => e !== 'tz1burnburnburnburnburnburnburjAYjjX') // remove burn wallet
+          .map((s) => ({ amount: owners[s], wallet: s }))) ||
+      [] */
 
   const handleCollect = (swap_id, price) => {
     if (acc == null) {
@@ -43,17 +43,18 @@ export const Collectors = ({ owners, swaps, token_holders }) => {
               handleCollect={handleCollect}
               acc={acc}
               cancel={cancel}
+              reswapv2={reswapv2}
             />
           </Padding>
         </Container>
       )}
 
       {/* {filtered.length === 0 ? undefined : ( */}
-        <Container>
-          <Padding>
-            <OwnerList owners={token_holders} />
-          </Padding>
-        </Container>
+      <Container>
+        <Padding>
+          <OwnerList owners={token_holders} />
+        </Padding>
+      </Container>
       {/* )} */}
     </>
   )


### PR DESCRIPTION
This patch allow a collector to change the price of swapped editions of an objkt.
Currently, to change a price, you have to unswap, wait for tx to complete, then swap at new price.
This patch do the same thing but in a batch that cancel current swap and do a new swap with new price provided by collector through UI.

It can be tested on a temporary instance run at https://alterhen.netlify.app/
I already used multiple time without problem.
Attached is a screenshot of the reswap UI
![reswap](https://user-images.githubusercontent.com/675/126617640-cd038153-b456-469b-b117-29f2276ea28d.jpg)

