### PR TITLE
Content security policy updates

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -179,6 +179,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       wss:
       bootstrap.libp2p.io
       preload.ipfs.io
+      https://mainnet.smartpy.io
       https://api.etherscan.io
       https://api.thegraph.com
       https://*.tzkt.io

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -159,6 +159,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://gateway.pinata.cloud/;
     font-src
       'self'
+      data:
       https://ipfs.infura.io
       https://cloudflare-ipfs.com/
       https://fonts.googleapis.com/

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -173,6 +173,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://*.infura.io
       https://infura.io
       blob:
+      data:
       ws:
       wss:
       bootstrap.libp2p.io


### PR DESCRIPTION
Updates the content security policy with the following rules:

1. Allow data url fonts (for base64 inline encoded fonts)
2. Allow data url sources (for small base64 encoded assets)
3. Allow smartpy mainnet node (to interact with rpc node)

Resolves #1020 and #1026 