### PR TITLE
Add giganode mainnet to the connect-src content security policy for interactive objkts

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -156,6 +156,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://ipfs.infura.io
       https://cloudflare-ipfs.com/
       https://ipfs.io/
+      https://templewallet.com/logo.png
       https://gateway.pinata.cloud/;
     font-src
       'self'

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -173,6 +173,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://cryptonomic-infra.tech
       https://*.infura.io
       https://infura.io
+      https://ipfs.io
       blob:
       data:
       ws:

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -174,7 +174,6 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://cryptonomic-infra.tech
       https://*.infura.io
       https://infura.io
-      https://ipfs.io
       blob:
       data:
       ws:
@@ -182,6 +181,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       bootstrap.libp2p.io
       preload.ipfs.io
       https://mainnet.smartpy.io
+      https://mainnet-tezos.giganode.io
       https://api.etherscan.io
       https://api.thegraph.com
       https://*.tzkt.io


### PR DESCRIPTION
The domain `https://mainnet-tezos.giganode.io ` was not on the `connect-src` content security policy for interactive objkts.