### PR TITLE
New infura ipfs redirect domain added to csp for interactive objkts

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -173,6 +173,7 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://*.cryptonomic-infra.tech
       https://cryptonomic-infra.tech
       https://*.infura.io
+      https://*.infura-ipfs.io
       https://infura.io
       blob:
       data:


### PR DESCRIPTION
Infura redirects requests to `xyz.infura-ipfs.io` which is not on the content security policy

`https://ipfs.infura.io/ipfs/QmSBc8QuynU7bArUGtjwCRhZUbJyZQArrczKnqM7hZPtfV` gets redirected to `https://bafybeibzdwnco7codoq5ipqsvai5snsg2mlgressp5jt4sagfjq2lrac2q.ipfs.infura-ipfs.io`

The solution is to add `*.infura-ipfs.io` to the content security policy