### PR TITLE
Missing space in About text

### DIFF
--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -82,7 +82,7 @@ export class About extends Component {
                   <strong>telegram</strong>
                 </Primary>
               </Button>
-              or through our
+              &nbsp;or through our
               <Button href="https://community.hicetnunc.xyz">
                 <Primary>
                   <strong>&nbsp;community forum</strong>


### PR DESCRIPTION
After the reference to Telegram there should be a non-breaking space inserted, as to separate the two words: 'telegram' and 'or'.