### PR TITLE
Feature - Add Discord Verification From Tezos Profiles to HEN

### DIFF
--- a/src/data/api.js
+++ b/src/data/api.js
@@ -171,6 +171,10 @@ export const GetUserMetadata = async (walletAddr) => {
           if (claimJSON.credentialSubject.alias !== "" && !(tzktData.data && tzktData.data.alias))
             tzpData['alias'] = claimJSON.credentialSubject.alias
           tzpData['tzprofile'] = walletAddr
+        } else if (claimJSON.type.includes('DiscordVerification')) {
+          if (!tzktData.data) {
+            tzpData['discord'] = claimJSON.evidence.handle
+          }
         }
       }
   } catch (e) {

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -308,9 +308,12 @@ export default class Display extends Component {
         const {
           twitter,
           tzprofile,
+          discord,
         } = data.data
+
         if (data.data.twitter) this.setState({ twitter })
         if (data.data.tzprofile) this.setState({ tzprofile })
+        if (data.data.discord) this.setState({ discord, copied: false })
       })
 
       let res = await fetchTz(wallet)
@@ -357,9 +360,11 @@ export default class Display extends Component {
 
       await GetUserMetadata(this.state.wallet).then((data) => {
         const {
+          discord,
           twitter,
           tzprofile
         } = data.data
+        if (data.data.discord) this.setState({ discord })
         if (data.data.twitter) this.setState({ twitter })
         if (data.data.tzprofile) this.setState({ tzprofile })
         this.onReady()
@@ -574,6 +579,17 @@ export default class Display extends Component {
     this.context.batch_cancel(this.state.marketV1.slice(0, 10))
   }
 
+  getDiscordTooltip() {
+    const handleSize = this.state.discord.length;
+    const missingSize = handleSize - 6;
+    const spaces = ' '.repeat(Math.ceil(Math.abs(missingSize / 2)));
+    if (missingSize < 0) {
+      return `${this.state.copied ? 'Copied' : `${spaces}${this.state.discord}${spaces}`}`;
+    } else {
+      return `${this.state.copied ? `${spaces}Copied${spaces}` : `${this.state.discord}`}`;
+    }
+  }
+
   render() {
     return (
       <Page title={this.state.alias}>
@@ -738,6 +754,38 @@ export default class Display extends Component {
                           <rect x="1" y="1" width="14" height="9" />
                         </g>
                       </svg>
+                    </Button>
+                  )}
+                  {this.state.discord && (
+                    <Button onClick={() => {
+                      this.setState({ copied: true })
+                      setTimeout(() => this.setState({ copied: false }), 1000)
+                      navigator.clipboard.writeText(this.state.discord)
+                    }}>
+                      <Primary>
+                        <span
+                          className={styles.top}
+                          data-position={'top'}
+                          data-tooltip={this.getDiscordTooltip()}
+                          style={{
+                            marginRight: '10px',
+                          }}
+                        >
+                          <VisuallyHidden>{`${this.state.discord}`}</VisuallyHidden>
+                          <svg
+                            width="20"
+                            height="15"
+                            viewBox="0 0 20 15"
+                            xmlns="http://www.w3.org/2000/svg"
+                            style={{
+                              fill: 'var(--text-color)',
+                              stroke: 'transparent',
+                            }}
+                          >
+                            <path d="M16.9308 1.24342C15.6561 0.667894 14.2892 0.243873 12.8599 0.00101874C12.8339 -0.00366827 12.8079 0.00804483 12.7945 0.0314716C12.6187 0.339138 12.4239 0.740513 12.2876 1.05599C10.7503 0.829542 9.22099 0.829542 7.71527 1.05599C7.57887 0.733501 7.37707 0.339138 7.20048 0.0314716C7.18707 0.00882646 7.16107 -0.00288664 7.13504 0.00101874C5.70659 0.243097 4.33963 0.667118 3.06411 1.24342C3.05307 1.2481 3.04361 1.25592 3.03732 1.26606C0.444493 5.07759 -0.265792 8.79544 0.0826501 12.4672C0.0842267 12.4852 0.0944749 12.5023 0.108665 12.5133C1.81934 13.7494 3.47642 14.4998 5.10273 14.9973C5.12876 15.0051 5.15634 14.9957 5.1729 14.9746C5.55761 14.4577 5.90054 13.9126 6.19456 13.3394C6.21192 13.3059 6.19535 13.266 6.15989 13.2528C5.61594 13.0497 5.098 12.8022 4.59977 12.5211C4.56037 12.4984 4.55721 12.443 4.59347 12.4164C4.69831 12.3391 4.80318 12.2587 4.9033 12.1775C4.92141 12.1626 4.94665 12.1595 4.96794 12.1689C8.24107 13.6393 11.7846 13.6393 15.0191 12.1689C15.0404 12.1587 15.0657 12.1619 15.0846 12.1767C15.1847 12.2579 15.2895 12.3391 15.3952 12.4164C15.4314 12.443 15.4291 12.4984 15.3897 12.5211C14.8914 12.8076 14.3735 13.0497 13.8288 13.252C13.7933 13.2653 13.7775 13.3059 13.7949 13.3394C14.0952 13.9118 14.4381 14.4569 14.8157 14.9738C14.8315 14.9957 14.8599 15.0051 14.8859 14.9973C16.5201 14.4998 18.1772 13.7494 19.8879 12.5133C19.9028 12.5023 19.9123 12.4859 19.9139 12.468C20.3309 8.22302 19.2154 4.53566 16.9568 1.26684C16.9513 1.25592 16.9419 1.2481 16.9308 1.24342ZM6.68335 10.2315C5.69792 10.2315 4.88594 9.34128 4.88594 8.24802C4.88594 7.15476 5.68217 6.26456 6.68335 6.26456C7.69239 6.26456 8.49651 7.16258 8.48073 8.24802C8.48073 9.34128 7.68451 10.2315 6.68335 10.2315ZM13.329 10.2315C12.3435 10.2315 11.5316 9.34128 11.5316 8.24802C11.5316 7.15476 12.3278 6.26456 13.329 6.26456C14.338 6.26456 15.1421 7.16258 15.1264 8.24802C15.1264 9.34128 14.338 10.2315 13.329 10.2315Z" />
+                          </svg>
+                        </span>
+                      </Primary>
                     </Button>
                   )}
                 </div>

--- a/src/pages/display/styles.module.scss
+++ b/src/pages/display/styles.module.scss
@@ -55,3 +55,69 @@
 .tag:hover {
   text-decoration: underline;
 }
+
+span[data-tooltip].top {
+  &:before,
+  &:after {
+    transform: translate(-50%, 10px);
+  }
+
+  &:hover:after,
+  &:hover:before {
+    transform: translate(-50%, 0px);
+  }
+}
+
+span[data-tooltip] {
+  position: relative;
+
+  &:after,
+  &:before {
+    position: absolute;
+    visibility: hidden;
+    opacity: 1;
+    transition: transform 200ms ease, opacity 200ms;
+    z-index: 99;
+  }
+
+  &:before {
+    content: attr(data-tooltip);
+    background-color: var(--text-color);
+    color: var(--background-color);
+    font-size: 12px;
+    font-weight: bold;
+    padding: 10px 15px;
+    border-radius: 10px;
+    white-space: nowrap;
+    text-decoration: none;
+    letter-spacing: 1px;
+  }
+
+  &:after {
+    width: 0;
+    height: 0;
+    left: 50%;
+    border: 6px solid transparent;
+    content: '';
+  }
+
+  &:hover:after,
+  &:hover:before {
+    visibility: visible;
+    opacity: 1;
+    transform: translate(-50%, 0px);
+  }
+}
+
+span[data-tooltip][data-position='top']:before {
+  bottom: 100%;
+  left: 50%;
+  margin-bottom: 9px;
+}
+
+span[data-tooltip][data-position='top']:after {
+  border-top-color: var(--text-color);
+  border-bottom: none;
+  bottom: 101%;
+  margin-bottom: 4px;
+}


### PR DESCRIPTION
This change adds a Discord badge to a creator's page if they have an existing Discord Verification created using the [Tezos Profiles](https://tzprofiles.com) service. The data is currently being pulled from the Tezos Profiles API.

Since Discord has no concept of a 'user page,' the badge on hover shows the user's handle, and when clicked, copies it to the clipboard. That handle can then be taken to the Discord app if they wish to message that user.

A demo deployment of the service with the add-on can be found [here](https://cf93be08.hicetnunc.pages.dev/).

Testing

Example of an existing profile with a [Discord verification](https://cf93be08.hicetnunc.pages.dev/Rocco/creations)

<img width="281" alt="Screen Shot 2021-08-24 at 7 38 26 PM" src="https://user-images.githubusercontent.com/18144858/130703612-bbfcf10f-c65c-46ac-a805-223631e34968.png">


