### PR TITLE
prevent number scrolling

### DIFF
--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -11,6 +11,7 @@ export const Input = ({
   label,
   onChange = () => null,
   onBlur = () => null,
+  onWheel = () => null,
   disabled,
   value,
   pattern
@@ -29,6 +30,7 @@ export const Input = ({
         onBlur={onBlur}
         disabled={disabled}
         pattern={pattern}
+        onWheel={onWheel}
       />
       <p>{label}</p>
     </label>

--- a/src/pages/objkt-display/tabs/swap.js
+++ b/src/pages/objkt-display/tabs/swap.js
@@ -95,6 +95,7 @@ export const Swap = ({ total_amount, owners, creator, royalties, token_info, add
                   defaultValue={amount}
                   /* max={total_amount - sales} */
                   onChange={(e) => setAmount(e.target.value)}
+                  onWheel={(e) => e.target.blur()} 
                   disabled={progress}
                 />
                 <div style={{ width: '100%', display: 'flex' }}>
@@ -106,6 +107,7 @@ export const Swap = ({ total_amount, owners, creator, royalties, token_info, add
                       min={0}
                       max={10000}
                       onChange={(e) => checkPrice(e.target.value)}
+                      onWheel={(e) => e.target.blur()} 
                       disabled={progress}
                     />
                   </div>


### PR DESCRIPTION
disable scroll on number fields on swap
prevents #1120 

works on windows, should test on mac & touch screen