### PR TITLE
Feature - Add GitHub Verification From Tezos Profiles to HEN

### DIFF
--- a/src/data/api.js
+++ b/src/data/api.js
@@ -175,6 +175,10 @@ export const GetUserMetadata = async (walletAddr) => {
           if (!tzktData.data) {
             tzpData['discord'] = claimJSON.evidence.handle
           }
+        } else if (claimJSON.type.includes('GitHubVerification')) {
+          if (!tzktData.data) {
+            tzpData['github'] = claimJSON.evidence.handle
+          }
         }
       }
   } catch (e) {

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -309,11 +309,13 @@ export default class Display extends Component {
           twitter,
           tzprofile,
           discord,
+          github,
         } = data.data
 
         if (data.data.twitter) this.setState({ twitter })
         if (data.data.tzprofile) this.setState({ tzprofile })
         if (data.data.discord) this.setState({ discord, copied: false })
+        if (data.data.github) this.setState({ github })
       })
 
       let res = await fetchTz(wallet)
@@ -360,10 +362,12 @@ export default class Display extends Component {
 
       await GetUserMetadata(this.state.wallet).then((data) => {
         const {
+          github,
           discord,
           twitter,
           tzprofile
         } = data.data
+        if (data.data.github) this.setState({ github })
         if (data.data.discord) this.setState({ discord })
         if (data.data.twitter) this.setState({ twitter })
         if (data.data.tzprofile) this.setState({ tzprofile })
@@ -694,25 +698,6 @@ export default class Display extends Component {
                       </svg>
                     </Button>
                   )}
-                  {this.state.github && (
-                    <Button href={`https://github.com/${this.state.github}`}>
-                      <VisuallyHidden>{`https://github.com/${this.state.github}`}</VisuallyHidden>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="16"
-                        height="16"
-                        fill="currentColor"
-                        viewBox="0 0 16 16"
-                        style={{
-                          fill: 'var(--text-color)',
-                          stroke: 'transparent',
-                          marginRight: '10px',
-                        }}
-                      >
-                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
-                      </svg>
-                    </Button>
-                  )}
                   {this.state.reddit && (
                     <Button href={`https://reddit.com/${this.state.reddit}`}>
                       <VisuallyHidden>{`https://reddit.com/${this.state.reddit}`}</VisuallyHidden>
@@ -786,6 +771,25 @@ export default class Display extends Component {
                           </svg>
                         </span>
                       </Primary>
+                    </Button>
+                  )}
+                  {this.state.github && (
+                    <Button href={`https://github.com/${this.state.github}`}>
+                      <VisuallyHidden>{`https://github.com/${this.state.github}`}</VisuallyHidden>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        fill="currentColor"
+                        viewBox="0 0 16 16"
+                        style={{
+                          fill: 'var(--text-color)',
+                          stroke: 'transparent',
+                          marginRight: '10px',
+                        }}
+                      >
+                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                      </svg>
                     </Button>
                   )}
                 </div>


### PR DESCRIPTION
This change adds a GitHub badge to a creator's page if they have an existing GitHub Verification created using the Tezos Profiles service. The data is currently being pulled from the Tezos Profiles API. The badge links out to the user's external GitHub account, based on the verification via the Tezos Profiles service. 

A demo deployment of the service with the add-on can be found [here](https://3e04fc5b.hicetnunc.pages.dev/).

Example of an existing profile with a [GitHub verification](https://3e04fc5b.hicetnunc.pages.dev/Rocco/creations).
<img width="523" alt="Screen Shot 2021-09-01 at 1 04 48 PM" src="https://user-images.githubusercontent.com/18144858/131713496-5f9717e5-ee71-4322-8f6d-5891df5d4fc3.png">
