### PR TITLE
Fixed tzprofiles config not showing up on dark mode

### DIFF
--- a/src/pages/config/index.js
+++ b/src/pages/config/index.js
@@ -222,7 +222,7 @@ export class Config extends Component {
           </Padding>
           <div style={{ display: 'inline' }}>
             <span>link your twitter account with </span>
-            <span><a style={{color : 'black', fontWeight : 'bold'}}href="https://tzprofiles.com">tz profiles</a></span>
+            <a href="https://tzprofiles.com"><button>tz profiles</button></a>
           </div>
         </Container>
 


### PR DESCRIPTION
Fixed #1128

Changed tzprofiles link to a button which works on both dark and light modes. It was hard coded to black with inline CSS before.