### PR TITLE
Duplicate worker-src policies under child-src 

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -138,7 +138,9 @@ export function injectCSPMetaTagIntoHTML(html) {
     frame-src
       'self';
     child-src
-      'self';
+      'self',
+      'unsafe-inline'
+      blob:;
     script-src
       'self'
       'unsafe-inline'


### PR DESCRIPTION
Safari does not have support for worker-src and will fall back to child-src

This is to address https://github.com/hicetnunc2000/hicetnunc/issues/1177