### PR TITLE
Fix errant comma

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -138,7 +138,7 @@ export function injectCSPMetaTagIntoHTML(html) {
     frame-src
       'self';
     child-src
-      'self',
+      'self'
       'unsafe-inline'
       blob:;
     script-src


### PR DESCRIPTION
As documented [in this comment on the original bug](https://github.com/hicetnunc2000/hicetnunc/issues/1177#issuecomment-943847556), there appears to be an errant comma in [this pull request that was merged](https://github.com/hicetnunc2000/hicetnunc/pull/1281/commits/28c042167baf219ac4812f4f716ad6431d4590f8#diff-2038d1cff314a89d519cf3c67de2d77db7b668bf2eae2f9dcd0d06aa875120ecR141). This pull request removes the extra comma. 