### PR TITLE
Bugfix - Prevent back button loop on Artist / Collector pages

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -35,11 +35,6 @@ export const routes = [
   },
   {
     exact: false,
-    path: '/tz/:id/:collection?',
-    component: Display,
-  },
-  {
-    exact: false,
     path: '/kt/:id',
     component: CollabDisplay,
   },
@@ -104,7 +99,7 @@ export const routes = [
   },
   {
     exact: false,
-    path: '/:id/:collection?',
+    path: ['/tz/:id/:collection?', '/:id/:collection?'],
     component: Display,
   },
 ]


### PR DESCRIPTION
You cannot currently navigate back from an artist's / collector's page if they have an alias name. This can be replicated by clicking on any profile name on the homepage (or any other page) and then hitting the back button. You will stay on that individual's profile no matter how many times you press the back button. This is because of some bad interactions between React Router and the way history is stored.

In the `Display` component, `componentWillMount` calls `onReady`, which involves pushing the active URL to the page history. However, downstream code also changes the URL of the page to include the alias (ex. to `/tezzardz_gone_wild` from `/tz/tz2PTETyPeF48fwbYNckycFGvrMye6YnDrnm`), which causes React Router to see this as navigation to a new page. Because of this, the component is remounted and `componentWillMount` is called again. This ends up adding another instance of the artist's / collector's profile to your page history -- meaning on every page load this is thrown in there twice.

If you hit the back button, it flips you from the alias page to the tz/... format, which remounts the component and pushes to the history again. Because of this, you are never able to back out of an artist's page.

This PR registers the alias and tz/... routes as the same route to prevent React Router from attempting to remount when flipping between these URLs. No visual changes or functionality changes occur, other than the back button working. In an attempt to keep this PR as small and legible as possible, I have not edited the code that involves both the alias and the tz/... format being pushed to page history, so it does still take hitting the back button twice to leave a page.