### PR TITLE
Bugfix/stop console errors

### DIFF
--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -607,15 +607,9 @@ export default class Display extends Component {
               <Identicon address={this.state.wallet} logo={this.state.identicon} />
 
               <div className={styles.info}>
-                {this.state.alias && !this.state.subjkt ? (
-                  <p>
-                    <strong>{this.state.alias}</strong>
-                  </p>
-                ) : (
-                  <p>
-                    <strong>{this.state.subjkt}</strong>
-                  </p>
-                )}
+                <p>
+                  <strong>{this.state.subjkt}</strong>
+                </p>
                 {this.state.description && <p>{this.state.description}</p>}
                 <Button href={`https://tzkt.io/${this.state.wallet}`}>
                   <Primary>{walletPreview(this.state.wallet)}</Primary>

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -600,7 +600,7 @@ export default class Display extends Component {
 
   render() {
     return (
-      <Page title={this.state.alias}>
+      <Page title={this.state.subjkt}>
         <Container>
           <Padding>
             <div className={styles.profile}>

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -870,7 +870,7 @@ export default class Display extends Component {
                   filter: !this.state.filter
                 })}>
                   <Primary>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-filter">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-filter">
                       <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
                     </svg>
                   </Primary>

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -301,48 +301,41 @@ export default class Display extends Component {
     collectionState: false,
     collectionType: 'notForSale',
     hdao: 0,
-    claim: []
+    claim: [],
+    discord: null,
+    discordLinkCopied: null,
+    dns: null,
+    github: null,
+    twitter: null,
+    tzprofile: null,
   }
 
   componentWillMount = async () => {
 
     const id = window.location.pathname.split('/')[1]
-    // console.log(window.location.pathname.split('/'))
 
     if (id === 'tz') {
 
       const wallet = window.location.pathname.split('/')[2]
+      this.setState({ wallet: wallet, walletPreview: walletPreview(wallet) })
 
-      this.setState({
-        wallet,
-        walletPreview: walletPreview(wallet),
-      })
-      //let res = await fetchSubjkts(decodeURI(window.location.pathname.split('/')[1]))
-      // console.log(decodeURI(window.location.pathname.split('/')[1]))
       await GetUserMetadata(wallet).then((data) => {
-        const {
-          twitter,
-          tzprofile,
-          discord,
-          github,
-          dns,
-        } = data.data
-
-        if (data.data.twitter) this.setState({ twitter })
-        if (data.data.tzprofile) this.setState({ tzprofile })
-        if (data.data.discord) this.setState({ discord, copied: false })
-        if (data.data.github) this.setState({ github })
-        if (data.data.dns) this.setState({ dns })
+        this.setState({
+          discord: data.data.discord,
+          dns: data.data.dns,
+          github: data.data.github,
+          twitter: data.data.twitter,
+          tzprofile: data.data.tzprofile
+        })
       })
+
       let res = await fetchTz(wallet)
       try {
         if (res[0]) {
-          let meta = await axios.get('https://cloudflare-ipfs.com/ipfs/' + res[0].metadata_file.split('//')[1]).then(res => res.data)
+          this.setState({ hdao: Math.floor(res[0].hdao_balance / 1000000), subjkt: res[0].name })
 
-          if (meta.description) this.setState({ description: meta.description })
-          if (meta.identicon) this.setState({ identicon: meta.identicon })
-          if (res[0]) this.setState({ subjkt: res[0].name })
-          if (res[0]) this.setState({ hdao: Math.floor(res[0].hdao_balance / 1000000) })
+          const meta = await axios.get('https://cloudflare-ipfs.com/ipfs/' + res[0].metadata_file.split('//')[1]).then(res => res.data)
+          if (meta.description) this.setState({ description: meta.description, identicon: meta.identicon })
         }
       } catch (e) {
         console.log("error " + e)
@@ -616,9 +609,9 @@ export default class Display extends Component {
     const missingSize = handleSize - 6;
     const spaces = ' '.repeat(Math.ceil(Math.abs(missingSize / 2)));
     if (missingSize < 0) {
-      return `${this.state.copied ? 'Copied' : `${spaces}${this.state.discord}${spaces}`}`;
+      return `${this.state.discordLinkCopied ? 'Copied' : `${spaces}${this.state.discord}${spaces}`}`;
     } else {
-      return `${this.state.copied ? `${spaces}Copied${spaces}` : `${this.state.discord}`}`;
+      return `${this.state.discordLinkCopied ? `${spaces}Copied${spaces}` : `${this.state.discord}`}`;
     }
   }
 
@@ -760,8 +753,8 @@ export default class Display extends Component {
                   )}
                   {this.state.discord && (
                     <Button onClick={() => {
-                      this.setState({ copied: true })
-                      setTimeout(() => this.setState({ copied: false }), 1000)
+                      this.setState({ discordLinkCopied: true })
+                      setTimeout(() => this.setState({ discordLinkCopied: false }), 1000)
                       navigator.clipboard.writeText(this.state.discord)
                     }}>
                       <Primary>

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -302,10 +302,12 @@ export default class Display extends Component {
     collectionType: 'notForSale',
     hdao: 0,
     claim: [],
+    description: null,
     discord: null,
     discordLinkCopied: null,
     dns: null,
     github: null,
+    identicon: null,
     twitter: null,
     tzprofile: null,
   }
@@ -335,7 +337,7 @@ export default class Display extends Component {
           this.setState({ hdao: Math.floor(res[0].hdao_balance / 1000000), subjkt: res[0].name })
 
           const meta = await axios.get('https://cloudflare-ipfs.com/ipfs/' + res[0].metadata_file.split('//')[1]).then(res => res.data)
-          if (meta.description) this.setState({ description: meta.description, identicon: meta.identicon })
+          this.setState({ description: meta.description, identicon: meta.identicon })
         }
       } catch (e) {
         console.log("error " + e)
@@ -346,10 +348,8 @@ export default class Display extends Component {
       // console.log(decodeURI(window.location.pathname.split('/')[1]))
       console.log(res)
       if (res[0].metadata_file) {
-        let meta = await axios.get('https://cloudflare-ipfs.com/ipfs/' + res[0].metadata_file.split('//')[1]).then(res => res.data)
-        console.log(meta)
-        if (meta.description) this.setState({ description: meta.description })
-        if (meta.identicon) this.setState({ identicon: meta.identicon })
+        const meta = await axios.get('https://cloudflare-ipfs.com/ipfs/' + res[0].metadata_file.split('//')[1]).then(res => res.data)
+        this.setState({ description: meta.description, identicon: meta.identicon })
       }
       if (res.length >= 1) {
         this.setState({

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -596,26 +596,10 @@ export default class Display extends Component {
 
   // called if there's no redirect
   onReady = async () => {
-
-    // based on route, define initial state
-    if (this.state.subjkt !== '') {
-      // if alias route
-      if (window.location.pathname.split('/')[2] === 'creations') {
-        this.creations()
-      } else if (window.location.pathname.split('/')[2] === 'collection') {
-        this.collectionFull()
-      } else {
-        this.creations()
-      }
+    if (window.location.pathname.split('/').pop() === 'collection') {
+      this.collectionFull()
     } else {
-      // if tz wallet route
-      if (window.location.pathname.split('/')[3] === 'creations') {
-        this.creations()
-      } else if (window.location.pathname.split('/')[3] === 'collection') {
-        this.collectionFull()
-      } else {
-        this.creations()
-      }
+      this.creations()
     }
   }
 

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -1011,12 +1011,10 @@ export default class Display extends Component {
               >
                 <ResponsiveMasonry>
                   {this.state.items.map((nft) => {
-                    // console.log('swaps ' + JSON.stringify(nft))
                     return (
-                      <div className={styles.cardContainer}>
+                      <div className={styles.cardContainer} key={nft.id}>
                         <Button
                           style={{ positon: 'relative' }}
-                          key={nft.id}
                           to={`${PATH.OBJKT}/${nft.id}`}>
                           <div className={styles.container}>
                             {renderMediaType({
@@ -1158,10 +1156,9 @@ export default class Display extends Component {
                   {this.state.items.map((nft) => {
                     //console.log('nft: ' + JSON.stringify(nft))
                     return (
-                      <div className={styles.cardContainer}>
+                      <div className={styles.cardContainer} key={nft.token.id}>
                         <Button
                           style={{ position: 'relative' }}
-                          key={nft.token.id}
                           to={`${PATH.OBJKT}/${nft.token.id}`}>
                           <div className={styles.container}>
                             {renderMediaType({

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -365,18 +365,13 @@ export default class Display extends Component {
       }
 
       await GetUserMetadata(this.state.wallet).then((data) => {
-        const {
-          dns,
-          github,
-          discord,
-          twitter,
-          tzprofile
-        } = data.data
-        if (data.data.dns) this.setState({ dns })
-        if (data.data.github) this.setState({ github })
-        if (data.data.discord) this.setState({ discord })
-        if (data.data.twitter) this.setState({ twitter })
-        if (data.data.tzprofile) this.setState({ tzprofile })
+        this.setState({
+          discord: data.data.discord,
+          dns: data.data.dns,
+          github: data.data.github,
+          twitter: data.data.twitter,
+          tzprofile: data.data.tzprofile
+        })
       })
       this.onReady()
     }
@@ -453,22 +448,10 @@ export default class Display extends Component {
       return objkts
     })
 
-    this.setState({ marketV1: v1Swaps, loading: false })
-    this.setState({ objkts: this.state.creations, loading: false, items: [] })
+    this.setState({ marketV1: v1Swaps, objkts: this.state.creations, loading: false, items: [] })
 
-    if (forSaleType !== null) {
-      if (forSaleType == 0) {
-        this.setState({
-          objkts: await this.filterCreationsForSalePrimary(this.state.objkts)
-        })
-      } else if (forSaleType == 1) {
-        this.setState({
-          objkts: await this.filterCreationsForSaleSecondary(this.state.objkts)
-        })
-      }
-    } else {
-      console.log("forSaleType is null")
-    }
+    if (forSaleType === 0) this.setState({ objkts: await this.filterCreationsForSalePrimary(this.state.objkts) })
+    if (forSaleType === 1) this.setState({ objkts: await this.filterCreationsForSaleSecondary(this.state.objkts) })
 
     this.setState({ items: this.state.objkts.slice(0, 15), offset: 15 })
   }


### PR DESCRIPTION
The console has a few errors on profile page load. This removes the errors coming from the below:
- one of the SVGs had multiple properties using dashes instead of camelCase (ex. `stroke-width` instead of `strokeWidth`), and React doesn't read these properly. Same with using `class` instead of using `className`
- two functions mapping arrays to HTML elements had the key on one of the children instead of the parent -- React wants keys on the topmost element when something is mapped

An additional bug was fixed:
-  this.state.alias is mentioned multiple times, but it does exist. This was improperly used causing every tab to have the title `hic et nunc - hic et nunc` instead of the profile's name (e.g. `tezzardz_gone_wild - hic et nunc`). This reference has been replaced with `this.state.subjkt` to fix the bug and other references removed

Several sections of code received some clean up, but no functionality change:
- `onReady` included a nested if statement that could be expressed using a single if statement
- the nested if statement used for filtering OBJKT sale type within `creationsForSale` can be expressed with two one-line if statements
- metadata fields are  set to `null` when the state is initialized to give a better indication of what will happen within the component
- instances where `getUserMetadata` is called wrote to an intermediate variable and had multiple unnecessary if statements where writing `null` or `undefined` would have the same outcome
- `this.state.copied` has been renamed to `this.state.discordLinkCopied` for clarity 